### PR TITLE
[UI] #51 카페 검색결과 상세페이지 말풍선 UI 개발

### DIFF
--- a/Projects/Coffice/Sources/App/Extensions/CofficeImages+Extensions.swift
+++ b/Projects/Coffice/Sources/App/Extensions/CofficeImages+Extensions.swift
@@ -1,0 +1,15 @@
+//
+//  CofficeImages+Extensions.swift
+//  coffice
+//
+//  Created by MinKyeongTae on 2023/06/27.
+//  Copyright © 2023 kr.co.yapp. All rights reserved.
+//
+
+import Foundation
+
+extension CofficeImages: Equatable {
+  public static func == (lhs: CofficeImages, rhs: CofficeImages) -> Bool {
+    lhs.name == rhs.name
+  }
+}

--- a/Projects/Coffice/Sources/App/Main/BubbleMessageCore.swift
+++ b/Projects/Coffice/Sources/App/Main/BubbleMessageCore.swift
@@ -1,0 +1,52 @@
+//
+//  BubbleMessageCore.swift
+//  coffice
+//
+//  Created by MinKyeongTae on 2023/06/27.
+//  Copyright (c) 2023 kr.co.yapp. All rights reserved.
+//
+
+import ComposableArchitecture
+import Foundation
+
+struct BubbleMessage: ReducerProtocol {
+  struct State: Equatable {
+    let title: String
+    let subTitle: String
+    let subInfoViewStates: [SubInfoViewState]
+  }
+
+  struct SubInfoViewState: Equatable, Identifiable {
+    let id = UUID()
+    let iconImage: CofficeImages
+    let title: String
+    let description: String
+  }
+
+  enum Action: Equatable {
+    case onAppear
+  }
+
+  var body: some ReducerProtocolOf<BubbleMessage> {
+    Reduce { state, action in
+      switch action {
+      case .onAppear:
+        return .none
+      }
+    }
+  }
+}
+
+extension BubbleMessage.State {
+  static var mock: Self {
+    .init(
+      title: "콘센트",
+      subTitle: "좌석대비 콘센트 비율",
+      subInfoViewStates: [
+        .init(iconImage: CofficeAsset.Asset.close40px, title: "넉넉:", description: "80% 이상"),
+        .init(iconImage: CofficeAsset.Asset.close40px, title: "보통:", description: "30% ~ 80%"),
+        .init(iconImage: CofficeAsset.Asset.close40px, title: "부족:", description: "30% 미만")
+      ]
+    )
+  }
+}

--- a/Projects/Coffice/Sources/App/Main/BubbleMessageView.swift
+++ b/Projects/Coffice/Sources/App/Main/BubbleMessageView.swift
@@ -1,0 +1,74 @@
+//
+//  BubbleMessageView.swift
+//  coffice
+//
+//  Created by MinKyeongTae on 2023/06/27.
+//  Copyright (c) 2023 kr.co.yapp. All rights reserved.
+//
+
+import ComposableArchitecture
+import SwiftUI
+
+struct BubbleMessageView: View {
+  private let store: StoreOf<BubbleMessage>
+
+  init(store: StoreOf<BubbleMessage>) {
+    self.store = store
+  }
+
+  var body: some View {
+    WithViewStore(store) { viewStore in
+      ZStack(alignment: .center) {
+        Color.black.opacity(0.4).ignoresSafeArea()
+
+        VStack(alignment: .leading, spacing: 0) {
+          Text(viewStore.title)
+            .foregroundColor(Color(asset: CofficeAsset.Colors.grayScale8))
+            .applyCofficeFont(font: .button)
+            .frame(height: 20, alignment: .leading)
+          Text(viewStore.subTitle)
+            .foregroundColor(Color(asset: CofficeAsset.Colors.grayScale6))
+            .applyCofficeFont(font: .body2)
+            .frame(height: 20, alignment: .leading)
+
+          VStack(spacing: 10) {
+            ForEach(viewStore.subInfoViewStates) { subInfoViewState in
+              HStack(spacing: 0) {
+                Image(asset: subInfoViewState.iconImage)
+                  .resizable()
+                  .frame(width: 20, height: 20)
+                Text(subInfoViewState.title)
+                  .foregroundColor(Color(asset: CofficeAsset.Colors.grayScale8))
+                  .applyCofficeFont(font: .body2Medium)
+                  .padding(.leading, 8)
+                Text(subInfoViewState.description)
+                  .foregroundColor(Color(asset: CofficeAsset.Colors.grayScale7))
+                  .applyCofficeFont(font: .body2Medium)
+                  .padding(.leading, 4)
+
+                Spacer()
+              }
+              .frame(height: 20)
+            }
+          }
+          .padding(.top, 24)
+        }
+        .padding(20)
+        .frame(width: 204, alignment: .center)
+        .background(Color(asset: CofficeAsset.Colors.grayScale1))
+        .cornerRadius(8)
+      }
+    }
+  }
+}
+
+struct BubbleMessageView_Previews: PreviewProvider {
+  static var previews: some View {
+    BubbleMessageView(
+      store: .init(
+        initialState: .mock,
+        reducer: BubbleMessage()
+      )
+    )
+  }
+}

--- a/Projects/Coffice/Sources/App/Main/MainCoordinatorCore.swift
+++ b/Projects/Coffice/Sources/App/Main/MainCoordinatorCore.swift
@@ -31,10 +31,7 @@ struct MainCoordinator: ReducerProtocol {
       tabBarState.selectedTab
     }
 
-    var bubbleMessageViewState: BubbleMessageViewState?
-    var isBubbleMessageViewPresented: Bool {
-      return bubbleMessageViewState != nil
-    }
+    var bubbleMessageState: BubbleMessage.State?
   }
 
   enum Action: Equatable {
@@ -43,6 +40,7 @@ struct MainCoordinator: ReducerProtocol {
     case savedList(SavedListCoordinator.Action)
     case myPage(MyPageCoordinator.Action)
     case tabBar(TabBar.Action)
+    case bubbleMessage(BubbleMessage.Action)
     case dismissBubbleMessageView
     case onAppear
   }
@@ -77,32 +75,19 @@ struct MainCoordinator: ReducerProtocol {
         debugPrint("selectedTab : \(itemType)")
         return .none
 
-      case .search(.routeAction(_, .cafeSearchDetail(.presentBubbleMessageView(let viewState)))):
-        state.bubbleMessageViewState = viewState
+      case .search(
+        .routeAction(_, .cafeSearchDetail(.presentBubbleMessageView(let bubbleMessageState)))
+      ):
+        state.bubbleMessageState = bubbleMessageState
         return .none
 
       case .dismissBubbleMessageView:
-        state.bubbleMessageViewState = nil
+        state.bubbleMessageState = nil
         return .none
 
       default:
         return .none
       }
     }
-  }
-}
-
-extension MainCoordinator.State {
-  struct BubbleMessageViewState: Equatable {
-    let title: String
-    let subTitle: String
-    let subInfoViewStates: [BubbleMessageSubInfoViewState]
-  }
-
-  struct BubbleMessageSubInfoViewState: Equatable, Identifiable {
-    let id = UUID()
-    let iconImage: CofficeImages
-    let title: String
-    let description: String
   }
 }

--- a/Projects/Coffice/Sources/App/Main/MainCoordinatorCore.swift
+++ b/Projects/Coffice/Sources/App/Main/MainCoordinatorCore.swift
@@ -30,6 +30,11 @@ struct MainCoordinator: ReducerProtocol {
     var selectedTab: TabBar.State.TabBarItemType {
       tabBarState.selectedTab
     }
+
+    var bubbleMessageViewState: BubbleMessageViewState?
+    var isBubbleMessageViewPresented: Bool {
+      return bubbleMessageViewState != nil
+    }
   }
 
   enum Action: Equatable {
@@ -38,6 +43,7 @@ struct MainCoordinator: ReducerProtocol {
     case savedList(SavedListCoordinator.Action)
     case myPage(MyPageCoordinator.Action)
     case tabBar(TabBar.Action)
+    case dismissBubbleMessageView
     case onAppear
   }
 
@@ -71,9 +77,32 @@ struct MainCoordinator: ReducerProtocol {
         debugPrint("selectedTab : \(itemType)")
         return .none
 
+      case .search(.routeAction(_, .cafeSearchDetail(.presentBubbleMessageView(let viewState)))):
+        state.bubbleMessageViewState = viewState
+        return .none
+
+      case .dismissBubbleMessageView:
+        state.bubbleMessageViewState = nil
+        return .none
+
       default:
         return .none
       }
     }
+  }
+}
+
+extension MainCoordinator.State {
+  struct BubbleMessageViewState: Equatable {
+    let title: String
+    let subTitle: String
+    let subInfoViewStates: [BubbleMessageSubInfoViewState]
+  }
+
+  struct BubbleMessageSubInfoViewState: Equatable, Identifiable {
+    let id = UUID()
+    let iconImage: CofficeImages
+    let title: String
+    let description: String
   }
 }

--- a/Projects/Coffice/Sources/App/Main/MainCoordinatorView.swift
+++ b/Projects/Coffice/Sources/App/Main/MainCoordinatorView.swift
@@ -20,6 +20,11 @@ struct MainCoordinatorView: View {
           mainView
         }
         tabBarView
+
+        if viewStore.isBubbleMessageViewPresented,
+           let viewState = viewStore.bubbleMessageViewState {
+          bubbleMessageView(viewState: viewState)
+        }
       }
       .onAppear {
         viewStore.send(.onAppear)
@@ -67,6 +72,56 @@ struct MainCoordinatorView: View {
             action: MainCoordinator.Action.tabBar
           )
         )
+      }
+    }
+  }
+
+  func bubbleMessageView(
+    viewState: MainCoordinator.State.BubbleMessageViewState
+  ) -> some View {
+    WithViewStore(store) { viewStore in
+      ZStack(alignment: .center) {
+        Color.black.opacity(0.4).ignoresSafeArea()
+
+        VStack(alignment: .leading, spacing: 0) {
+          Text(viewState.title)
+            .foregroundColor(Color(asset: CofficeAsset.Colors.grayScale8))
+            .applyCofficeFont(font: .button)
+            .frame(height: 20, alignment: .leading)
+          Text(viewState.subTitle)
+            .foregroundColor(Color(asset: CofficeAsset.Colors.grayScale6))
+            .applyCofficeFont(font: .body2)
+            .frame(height: 20, alignment: .leading)
+
+          VStack(spacing: 10) {
+            ForEach(viewState.subInfoViewStates) { subInfoViewState in
+              HStack(spacing: 0) {
+                Image(asset: subInfoViewState.iconImage)
+                  .resizable()
+                  .frame(width: 20, height: 20)
+                Text(subInfoViewState.title)
+                  .foregroundColor(Color(asset: CofficeAsset.Colors.grayScale8))
+                  .applyCofficeFont(font: .body2Medium)
+                  .padding(.leading, 8)
+                Text(subInfoViewState.description)
+                  .foregroundColor(Color(asset: CofficeAsset.Colors.grayScale7))
+                  .applyCofficeFont(font: .body2Medium)
+                  .padding(.leading, 4)
+
+                Spacer()
+              }
+              .frame(height: 20)
+            }
+          }
+          .padding(.top, 24)
+        }
+        .padding(20)
+        .frame(width: 204, alignment: .center)
+        .background(Color(asset: CofficeAsset.Colors.grayScale1))
+        .cornerRadius(8)
+      }
+      .onTapGesture {
+        viewStore.send(.dismissBubbleMessageView)
       }
     }
   }

--- a/Projects/Coffice/Sources/App/Main/MainCoordinatorView.swift
+++ b/Projects/Coffice/Sources/App/Main/MainCoordinatorView.swift
@@ -21,9 +21,15 @@ struct MainCoordinatorView: View {
         }
         tabBarView
 
-        if viewStore.isBubbleMessageViewPresented,
-           let viewState = viewStore.bubbleMessageViewState {
-          bubbleMessageView(viewState: viewState)
+        IfLetStore(
+          store.scope(
+            state: \.bubbleMessageState,
+            action: MainCoordinator.Action.bubbleMessage
+          ),
+          then: BubbleMessageView.init
+        )
+        .onTapGesture {
+          viewStore.send(.dismissBubbleMessageView)
         }
       }
       .onAppear {
@@ -72,56 +78,6 @@ struct MainCoordinatorView: View {
             action: MainCoordinator.Action.tabBar
           )
         )
-      }
-    }
-  }
-
-  func bubbleMessageView(
-    viewState: MainCoordinator.State.BubbleMessageViewState
-  ) -> some View {
-    WithViewStore(store) { viewStore in
-      ZStack(alignment: .center) {
-        Color.black.opacity(0.4).ignoresSafeArea()
-
-        VStack(alignment: .leading, spacing: 0) {
-          Text(viewState.title)
-            .foregroundColor(Color(asset: CofficeAsset.Colors.grayScale8))
-            .applyCofficeFont(font: .button)
-            .frame(height: 20, alignment: .leading)
-          Text(viewState.subTitle)
-            .foregroundColor(Color(asset: CofficeAsset.Colors.grayScale6))
-            .applyCofficeFont(font: .body2)
-            .frame(height: 20, alignment: .leading)
-
-          VStack(spacing: 10) {
-            ForEach(viewState.subInfoViewStates) { subInfoViewState in
-              HStack(spacing: 0) {
-                Image(asset: subInfoViewState.iconImage)
-                  .resizable()
-                  .frame(width: 20, height: 20)
-                Text(subInfoViewState.title)
-                  .foregroundColor(Color(asset: CofficeAsset.Colors.grayScale8))
-                  .applyCofficeFont(font: .body2Medium)
-                  .padding(.leading, 8)
-                Text(subInfoViewState.description)
-                  .foregroundColor(Color(asset: CofficeAsset.Colors.grayScale7))
-                  .applyCofficeFont(font: .body2Medium)
-                  .padding(.leading, 4)
-
-                Spacer()
-              }
-              .frame(height: 20)
-            }
-          }
-          .padding(.top, 24)
-        }
-        .padding(20)
-        .frame(width: 204, alignment: .center)
-        .background(Color(asset: CofficeAsset.Colors.grayScale1))
-        .cornerRadius(8)
-      }
-      .onTapGesture {
-        viewStore.send(.dismissBubbleMessageView)
       }
     }
   }

--- a/Projects/Coffice/Sources/App/Main/Search/CafeSearchDetailCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeSearchDetailCore.swift
@@ -51,7 +51,7 @@ struct CafeSearchDetail: ReducerProtocol {
     case subMenuTapped(State.SubMenuType)
     case toggleToPresentTextForTest
     case infoGuideButtonTapped
-    case presentBubbleMessageView(MainCoordinator.State.BubbleMessageViewState)
+    case presentBubbleMessageView(BubbleMessage.State)
   }
 
   @Dependency(\.apiClient) private var apiClient
@@ -78,19 +78,7 @@ struct CafeSearchDetail: ReducerProtocol {
 
       case .infoGuideButtonTapped:
         // TODO: 선택한 버튼에 맞게 맞춤형 정보가 있는 말풍선 표출 필요
-        return EffectTask(
-          value: .presentBubbleMessageView(
-            .init(
-              title: "콘센트",
-              subTitle: "좌석대비 콘센트 비율",
-              subInfoViewStates: [
-                .init(iconImage: CofficeAsset.Asset.close40px, title: "넉넉:", description: "80% 이상"),
-                .init(iconImage: CofficeAsset.Asset.close40px, title: "보통:", description: "30% ~ 80%"),
-                .init(iconImage: CofficeAsset.Asset.close40px, title: "부족:", description: "30% 미만")
-              ]
-            )
-          )
-        )
+        return EffectTask(value: .presentBubbleMessageView(.mock))
 
       default:
         return .none

--- a/Projects/Coffice/Sources/App/Main/Search/CafeSearchDetailCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeSearchDetailCore.swift
@@ -50,6 +50,8 @@ struct CafeSearchDetail: ReducerProtocol {
     case popView
     case subMenuTapped(State.SubMenuType)
     case toggleToPresentTextForTest
+    case infoGuideButtonTapped
+    case presentBubbleMessageView(MainCoordinator.State.BubbleMessageViewState)
   }
 
   @Dependency(\.apiClient) private var apiClient
@@ -74,12 +76,30 @@ struct CafeSearchDetail: ReducerProtocol {
         }
         return .none
 
+      case .infoGuideButtonTapped:
+        // TODO: 선택한 버튼에 맞게 맞춤형 정보가 있는 말풍선 표출 필요
+        return EffectTask(
+          value: .presentBubbleMessageView(
+            .init(
+              title: "콘센트",
+              subTitle: "좌석대비 콘센트 비율",
+              subInfoViewStates: [
+                .init(iconImage: CofficeAsset.Asset.close40px, title: "넉넉:", description: "80% 이상"),
+                .init(iconImage: CofficeAsset.Asset.close40px, title: "보통:", description: "30% ~ 80%"),
+                .init(iconImage: CofficeAsset.Asset.close40px, title: "부족:", description: "30% 미만")
+              ]
+            )
+          )
+        )
+
       default:
         return .none
       }
     }
   }
 }
+
+// MARK: - Sub Views State
 
 extension CafeSearchDetail.State {
   enum SubMenuType: CaseIterable {

--- a/Projects/Coffice/Sources/App/Main/Search/CafeSearchDetailMenuView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeSearchDetailMenuView.swift
@@ -329,11 +329,11 @@ extension CafeSearchDetailMenuView {
               Text("수민")
                 .font(.system(size: 16, weight: .bold))
                 .foregroundColor(.black)
-                .frame(alignment: .leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
               Text("5.24 토")
                 .font(.system(size: 12))
                 .foregroundColor(.gray)
-                .frame(alignment: .leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
               Spacer()
             }
 

--- a/Projects/Coffice/Sources/App/Main/Search/CafeSearchDetailSubInfoView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeSearchDetailSubInfoView.swift
@@ -50,6 +50,16 @@ extension CafeSearchDetailSubInfoView {
               Image(systemName: viewState.iconName)
                 .resizable()
                 .frame(width: 30, height: 30)
+                .overlay(alignment: .topTrailing) {
+                  Button {
+                    viewStore.send(.infoGuideButtonTapped)
+                  } label: {
+                    Image(asset: CofficeAsset.Asset.informationLine18px)
+                      .resizable()
+                      .frame(width: 18, height: 18)
+                  }
+                  .offset(x: 5, y: -5)
+                }
               HStack(spacing: 8) {
                 Text(viewState.title)
                   .foregroundColor(.black)


### PR DESCRIPTION
## ☕️ PR 요약
- 말풍선 UI 및 상세정보 페이지의 가이드 버튼 탭 시 말풍선 표출 하는 플로우를 구성
- 말풍선 background가 탭바까지 가려야 해서 카페 상세 화면의 이벤트를 MainCoordinator에서 받아서 처리하는 방식으로 구현했습니다. (추후 커스텀 UI로 분리 및 개선을 해야겠습니다.)



## 📸 ScreenShot
<div>
<img src="https://github.com/YAPP-Github/22nd-iOS-Team-1-iOS/assets/4410021/46a58da7-5a5f-4c05-b2f9-f9bb7bc8560b" width="200">
<img src="https://github.com/YAPP-Github/22nd-iOS-Team-1-iOS/assets/4410021/b851efa3-8dc7-4d55-95b3-1771b7e773c6" width="200">
</div>


##### ✅ PR check list(PR 요청시 확인후 삭제해주세요)
- 카페 상세화면 > 가이드 버튼(i 모양 버튼) 클릭 후 UI 확인 (현재는 샘플 데이터만 나옵니다.)

```
- commit message가 적절한지 확인해주세요.
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```



#### Linked Issue

close #51 
