### PR TITLE
[Fix] #85 검색바 키워드 입력 시 바인딩 이벤트 실행되지 않는 문제 수정

### DIFF
--- a/Projects/Coffice/Sources/App/Main/Search/CafeMapCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeMapCore.swift
@@ -83,7 +83,6 @@ struct CafeMapCore: ReducerProtocol {
 
     case requestLocationAuthorization
 
-    case searchTextDidChanged(text: String)
     case searchTextFieldClearButtonClicked
     case searchTextFieldClearButtonTapped
     case searchTextSubmitted
@@ -102,6 +101,9 @@ struct CafeMapCore: ReducerProtocol {
 
     Reduce { state, action in
       switch action {
+      case .binding(\.$searchText):
+        debugPrint("searchText : \(state.searchText)")
+        return .none
 
       case .cameraDidChange(let location):
         state.region = location
@@ -159,10 +161,6 @@ struct CafeMapCore: ReducerProtocol {
         default:
           return .none
         }
-
-      case .searchTextDidChanged(let text):
-        state.searchText = text
-        return .none
 
       case .searchTextFieldClearButtonTapped:
         state.searchText = ""

--- a/Projects/Coffice/Sources/App/Main/Search/CafeMapView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeMapView.swift
@@ -77,6 +77,7 @@ extension CafeMapView {
           "🔍  지역, 지하철로 검색",
           text: viewStore.binding(\.$searchText)
         )
+        .textFieldStyle(.plain)
         .frame(height: 35)
         .padding(.leading, 5)
         .padding(.trailing, 25)


### PR DESCRIPTION
## ☕️ PR 요약
- 검색바 키워드 입력 시 바인딩 이벤트가 연결되도록 수정
  - 바인딩 활용하여 개발 시 확인해야 부분 : 키워드 입력으로 바인딩 이벤트 발생 시, 2번씩 action이 호출되어서 이부분 원래이러는지, 버그인지 확인이 필요합니다.


##### ✅ PR check list(PR 요청시 확인후 삭제해주세요)
- 검색 키워드 입력 시 바인딩 이벤트 잘 동작하는지 확인 필요

```
- commit message가 적절한지 확인해주세요.
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```



#### Linked Issue

close #85 
