### PR TITLE
[Fix] #91 리뷰 작성화면 텍스트 뷰 편집 시 편집 사용성 개선

### DIFF
--- a/Projects/Coffice/Sources/App/Main/Search/Detail/Review/CafeReviewTextView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/Review/CafeReviewTextView.swift
@@ -32,12 +32,12 @@ struct CafeReviewTextView: UIViewRepresentable {
   }
 
   class Coordinator: NSObject {
-    var text: Binding<String>
+    @Binding private(set) var text: String
     let maxTextLength: Int = 200
     let maxNumberOfLine: Int = 11
 
     init(_ text: Binding<String>) {
-      self.text = text
+      self._text = text
     }
   }
 }
@@ -51,7 +51,7 @@ extension CafeReviewTextView.Coordinator: UITextViewDelegate {
     }
 
     textView.text = updatedText
-    text.wrappedValue = updatedText
+    $text.wrappedValue = updatedText
   }
 
   func sizeOf(string: String, constrainedToWidth width: Double, font: UIFont) -> CGSize {

--- a/Projects/Coffice/Sources/App/Main/Search/Detail/Review/CafeReviewTextView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/Review/CafeReviewTextView.swift
@@ -33,6 +33,8 @@ struct CafeReviewTextView: UIViewRepresentable {
 
   class Coordinator: NSObject {
     var text: Binding<String>
+    let maxTextLength: Int = 200
+    let maxNumberOfLine: Int = 11
 
     init(_ text: Binding<String>) {
       self.text = text
@@ -41,8 +43,6 @@ struct CafeReviewTextView: UIViewRepresentable {
 }
 
 extension CafeReviewTextView.Coordinator: UITextViewDelegate {
-  var maxTextLength: Int { 200 }
-
   func textViewDidChange(_ textView: UITextView) {
     var updatedText = textView.text ?? ""
 
@@ -52,5 +52,27 @@ extension CafeReviewTextView.Coordinator: UITextViewDelegate {
 
     textView.text = updatedText
     text.wrappedValue = updatedText
+  }
+
+  func sizeOf(string: String, constrainedToWidth width: Double, font: UIFont) -> CGSize {
+    return (string as NSString).boundingRect(
+      with: CGSize(width: width, height: .greatestFiniteMagnitude),
+      options: NSStringDrawingOptions.usesLineFragmentOrigin,
+      attributes: [.font: font],
+      context: nil
+    ).size
+  }
+
+  func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+    guard let font = textView.font else { return false }
+
+    let newText = (textView.text as NSString).replacingCharacters(in: range, with: text)
+    var textWidth = textView.frame.inset(by: textView.textContainerInset).width
+    textWidth -= 2.0 * textView.textContainer.lineFragmentPadding
+
+    let boundingRect = sizeOf(string: newText, constrainedToWidth: Double(textWidth), font: font)
+    let numberOfLines = boundingRect.height / font.lineHeight
+
+    return numberOfLines <= 11
   }
 }

--- a/Projects/Coffice/Sources/App/Main/Search/Detail/Review/CafeReviewWriteCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/Review/CafeReviewWriteCore.swift
@@ -27,10 +27,11 @@ struct CafeReviewWrite: ReducerProtocol {
 
     var isSaveButtonEnabled = false
     @BindingState var reviewText = ""
-    let textViewScrollId = UUID()
-    let mainScrollViewScrollId = UUID()
+    let textViewDidBeginEditingScrollId = UUID()
+    let textViewDidEndEditingScrollId = UUID()
     let maximumTextLength = 200
 
+    var textViewBottomPadding: CGFloat = 0.0
     var saveButtonBackgroundColorAsset: CofficeColors {
       return isSaveButtonEnabled ? CofficeAsset.Colors.grayScale9 : CofficeAsset.Colors.grayScale6
     }
@@ -68,6 +69,7 @@ struct CafeReviewWrite: ReducerProtocol {
     case dismissView
     case optionButtonsAction(CafeReviewOptionButtons.Action)
     case updateSaveButtonState
+    case updateTextViewBottomPadding(isTextViewEditing: Bool)
   }
 
   var body: some ReducerProtocolOf<CafeReviewWrite> {
@@ -94,6 +96,10 @@ struct CafeReviewWrite: ReducerProtocol {
 
       case .updateSaveButtonState:
         state.isSaveButtonEnabled = state.optionButtonStates.allSatisfy(\.isSelectedOptionButton)
+        return .none
+
+      case .updateTextViewBottomPadding(let isTextViewEditing):
+        state.textViewBottomPadding = isTextViewEditing ? 200 : 0
         return .none
 
       default:

--- a/Projects/Coffice/Sources/App/Main/Search/Detail/Review/CafeReviewWriteView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/Review/CafeReviewWriteView.swift
@@ -32,6 +32,7 @@ struct CafeReviewWriteView: View {
           }
         }
         .padding(.top, 24)
+        .padding(.horizontal, 20)
         .padding(.bottom, 16)
 
         HStack {
@@ -59,10 +60,12 @@ struct CafeReviewWriteView: View {
         }
         .padding(.top, 4)
         .padding(.bottom, 16)
+        .padding(.horizontal, 20)
 
         Divider()
           .background(Color(asset: CofficeAsset.Colors.grayScale3))
           .frame(height: 1)
+          .padding(.horizontal, 20)
 
         reviewFormScrollView
 
@@ -80,9 +83,9 @@ struct CafeReviewWriteView: View {
         .frame(height: 44)
         .background(Color(asset: viewStore.saveButtonBackgroundColorAsset))
         .cornerRadius(4, corners: .allCorners)
+        .padding(.horizontal, 20)
       }
       .ignoresSafeArea(.keyboard)
-      .padding(.horizontal, 20)
       .onAppear {
         viewStore.send(.onAppear)
       }
@@ -101,9 +104,11 @@ extension CafeReviewWriteView: KeyboardPresentationReadable {
           VStack(spacing: 0) {
             reviewOptionMenuView
               .id(viewStore.textViewDidEndEditingScrollId)
+              .padding(.horizontal, 20)
             reviewTextView
               .padding(.bottom, viewStore.textViewBottomPadding)
               .id(viewStore.textViewDidBeginEditingScrollId)
+              .padding(.horizontal, 20)
           }
         }
         .onReceive(keyboardEventPublisher) { isKeyboardShowing in

--- a/Projects/Coffice/Sources/App/Main/Search/Detail/Review/CafeReviewWriteView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/Review/CafeReviewWriteView.swift
@@ -86,6 +86,9 @@ struct CafeReviewWriteView: View {
       .onAppear {
         viewStore.send(.onAppear)
       }
+      .onTapGesture {
+        UIApplication.keyWindow?.endEditing(true)
+      }
     }
   }
 }
@@ -97,15 +100,19 @@ extension CafeReviewWriteView: KeyboardPresentationReadable {
         ScrollView(.vertical, showsIndicators: true) {
           VStack(spacing: 0) {
             reviewOptionMenuView
+              .id(viewStore.textViewDidEndEditingScrollId)
             reviewTextView
+              .padding(.bottom, viewStore.textViewBottomPadding)
+              .id(viewStore.textViewDidBeginEditingScrollId)
           }
         }
-        .id(viewStore.mainScrollViewScrollId)
-        .onReceive(eventPublisher) { isShowing in
-          if isShowing {
-            proxy.scrollTo(viewStore.textViewScrollId, anchor: .bottom)
+        .onReceive(keyboardEventPublisher) { isKeyboardShowing in
+          viewStore.send(.updateTextViewBottomPadding(isTextViewEditing: isKeyboardShowing))
+
+          if isKeyboardShowing {
+            proxy.scrollTo(viewStore.textViewDidBeginEditingScrollId, anchor: .bottom)
           } else {
-            proxy.scrollTo(viewStore.mainScrollViewScrollId, anchor: .bottom)
+            proxy.scrollTo(viewStore.textViewDidEndEditingScrollId, anchor: .bottom)
           }
         }
       }
@@ -144,7 +151,6 @@ extension CafeReviewWriteView: KeyboardPresentationReadable {
                   lineWidth: 1
                 )
             }
-            .id(viewStore.textViewScrollId)
         }
         .padding(.top, 16)
 

--- a/Projects/Coffice/Sources/App/Main/Search/Detail/Review/CafeReviewWriteView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/Review/CafeReviewWriteView.swift
@@ -139,6 +139,7 @@ extension CafeReviewWriteView: KeyboardPresentationReadable {
       ZStack(alignment: .topLeading) {
         VStack(alignment: .leading, spacing: 0) {
           CafeReviewTextView(text: viewStore.binding(\.$reviewText))
+            .textFieldStyle(.plain)
             .frame(height: 206)
             .overlay(
               textDescriptionView, alignment: .bottomTrailing

--- a/Projects/Coffice/Sources/App/Main/Search/Detail/Review/KeyboardPresentationReadable.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/Review/KeyboardPresentationReadable.swift
@@ -10,11 +10,11 @@ import Combine
 import UIKit
 
 protocol KeyboardPresentationReadable {
-  var eventPublisher: AnyPublisher<Bool, Never> { get }
+  var keyboardEventPublisher: AnyPublisher<Bool, Never> { get }
 }
 
 extension KeyboardPresentationReadable {
-  var eventPublisher: AnyPublisher<Bool, Never> {
+  var keyboardEventPublisher: AnyPublisher<Bool, Never> {
     Publishers.Merge(
       NotificationCenter.default
         .publisher(for: UIResponder.keyboardWillShowNotification)


### PR DESCRIPTION
## ☕️ PR 요약
- iOS 16 이상에서 키보드가 올라왔을때 키보드 위로 텍스트뷰 보이지 않는 문제 수정
  - iOS15, 16 모두 동작 확인
- 편집 상태에서 빈 뷰 탭 하는 경우, 키보드 내려가고, 텍스트뷰 원 위치로 이동하도록 수정



## 📸 ScreenShot
|          AS-IS          |          TO-BE          |
| :---------------------: | :---------------------: |
<div>
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/a8ed989f-c01d-46d9-b1c2-c4ea947a0852" width="200">
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/a3949bfd-e670-4ab9-8e61-760bd0a1ec65" width="200">
</div>




##### ✅ PR check list(PR 요청시 확인후 삭제해주세요)

```
- commit message가 적절한지 확인해주세요.
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```



#### Linked Issue

close #91 
