### PR TITLE
Feature/#94 bookmark view 제작

### DIFF
--- a/Projects/Coffice/Resources/Colors.xcassets/grayScale8.colorset/Contents.json
+++ b/Projects/Coffice/Resources/Colors.xcassets/grayScale8.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.361",
-          "green" : "0.341",
-          "red" : "0.337"
+          "blue" : "0x52",
+          "green" : "0x48",
+          "red" : "0x46"
         }
       },
       "idiom" : "iphone"

--- a/Projects/Coffice/Sources/App/Dependencies/BookmarkAPIClient.swift
+++ b/Projects/Coffice/Sources/App/Dependencies/BookmarkAPIClient.swift
@@ -45,7 +45,7 @@ struct BookmarkAPIClient: DependencyKey {
     let coreNetwork = CoreNetwork.shared
     var urlComponents = URLComponents(string: coreNetwork.baseURL)
     urlComponents?.path = "/api/v1/members/me/places"
-    guard let requestBody = try? JSONEncoder().encode(SavePlacesRequestDTO(placeIds: placeIds))
+    guard let requestBody = try? JSONEncoder().encode(SavePlacesRequestDTO(postIds: placeIds))
     else { throw LoginError.jsonEncodeFailed }
     guard let request = urlComponents?.toURLRequest(method: .delete, httpBody: requestBody)
     else { throw LoginError.emptyAccessToken }

--- a/Projects/Coffice/Sources/App/Dependencies/BookmarkAPIClient.swift
+++ b/Projects/Coffice/Sources/App/Dependencies/BookmarkAPIClient.swift
@@ -17,42 +17,39 @@ struct BookmarkAPIClient: DependencyKey {
     let coreNetwork = CoreNetwork.shared
     var urlComponents = URLComponents(string: coreNetwork.baseURL)
     urlComponents?.path = "/api/v1/members/me/places"
-    guard let request = urlComponents?.toURLRequest(method: .get) else {
-      throw CoreNetworkError.requestConvertFailed
-    }
-    let response: [SearchPlaceResponseDTO] = try await coreNetwork.dataTask(request: request)
+    guard let request = urlComponents?.toURLRequest(method: .get)
+    else { throw CoreNetworkError.requestConvertFailed }
+    let response: [PlaceResponseDTO] = try await coreNetwork.dataTask(request: request)
     return response.map { $0.toCafeEntity() }
   }
 
-  func addMyPlace(placeId: Int, folderId: Int) async throws -> HTTPURLResponse {
+  func addMyPlace(placeId: Int) async throws {
     let coreNetwork = CoreNetwork.shared
     var urlComponents = URLComponents(string: coreNetwork.baseURL)
-    urlComponents?.path = "/api/v1/places/\(placeId)/save-to-folder"
-    let requestValue = SaveToFolderRequestDTO(placeFolderId: folderId)
-    guard let requestBody = try? JSONEncoder()
-      .encode(requestValue) else {
-      throw CoreNetworkError.jsonEncodeFailed
-    }
-    guard let request = urlComponents?.toURLRequest(
-      method: .post,
-      httpBody: requestBody
-    ) else {
-      throw CoreNetworkError.jsonEncodeFailed
-    }
-    dump(request)
-    let response = try await coreNetwork.dataTask(request: request)
-    return response
+    urlComponents?.path = "/api/v1/members/me/places/\(placeId)"
+    guard let request = urlComponents?.toURLRequest(method: .post)
+    else { throw CoreNetworkError.jsonEncodeFailed }
+    _ = try await coreNetwork.dataTask(request: request)
   }
 
-  func deleteMyPlace(placeId: Int) async throws -> HTTPURLResponse {
+  func deleteMyPlace(placeId: Int) async throws {
     let coreNetwork = CoreNetwork.shared
     var urlComponents = URLComponents(string: coreNetwork.baseURL)
-    urlComponents?.path = "/api/v1/places/\(placeId)/delete-from-folder"
-    guard let request = urlComponents?.toURLRequest(method: .delete) else {
-      throw CoreNetworkError.requestConvertFailed
-    }
-    let response = try await coreNetwork.dataTask(request: request)
-    return response
+    urlComponents?.path = "/api/v1/members/me/places/\(placeId)"
+    guard let request = urlComponents?.toURLRequest(method: .delete)
+    else { throw CoreNetworkError.requestConvertFailed }
+    _ =  try await coreNetwork.dataTask(request: request)
+  }
+
+  func deleteMyPlaces(placeIds: [Int]) async throws {
+    let coreNetwork = CoreNetwork.shared
+    var urlComponents = URLComponents(string: coreNetwork.baseURL)
+    urlComponents?.path = "/api/v1/members/me/places"
+    guard let requestBody = try? JSONEncoder().encode(SavePlacesRequestDTO(placeIds: placeIds))
+    else { throw LoginError.jsonEncodeFailed }
+    guard let request = urlComponents?.toURLRequest(method: .delete, httpBody: requestBody)
+    else { throw LoginError.emptyAccessToken }
+    _ = try await coreNetwork.dataTask(request: request)
   }
 }
 

--- a/Projects/Coffice/Sources/App/Dependencies/BookmarkAPIClient.swift
+++ b/Projects/Coffice/Sources/App/Dependencies/BookmarkAPIClient.swift
@@ -13,7 +13,7 @@ import Network
 struct BookmarkAPIClient: DependencyKey {
   static var liveValue: BookmarkAPIClient = .liveValue
 
-  func fetchMyPlaces() async throws -> [SearchPlaceResponseDTO] {
+  func fetchMyPlaces() async throws -> [Cafe] {
     let coreNetwork = CoreNetwork.shared
     var urlComponents = URLComponents(string: coreNetwork.baseURL)
     urlComponents?.path = "/api/v1/members/me/places"
@@ -21,16 +21,25 @@ struct BookmarkAPIClient: DependencyKey {
       throw CoreNetworkError.requestConvertFailed
     }
     let response: [SearchPlaceResponseDTO] = try await coreNetwork.dataTask(request: request)
-    return response
+    return response.map { $0.toCafeEntity() }
   }
 
-  func addMyPlace(placeId: Int) async throws -> HTTPURLResponse {
+  func addMyPlace(placeId: Int, folderId: Int) async throws -> HTTPURLResponse {
     let coreNetwork = CoreNetwork.shared
     var urlComponents = URLComponents(string: coreNetwork.baseURL)
-    urlComponents?.path = "/api/v1/members/me/places/\(placeId)"
-    guard let request = urlComponents?.toURLRequest(method: .post) else {
-      throw CoreNetworkError.requestConvertFailed
+    urlComponents?.path = "/api/v1/places/\(placeId)/save-to-folder"
+    let requestValue = SaveToFolderRequestDTO(placeFolderId: folderId)
+    guard let requestBody = try? JSONEncoder()
+      .encode(requestValue) else {
+      throw CoreNetworkError.jsonEncodeFailed
     }
+    guard let request = urlComponents?.toURLRequest(
+      method: .post,
+      httpBody: requestBody
+    ) else {
+      throw CoreNetworkError.jsonEncodeFailed
+    }
+    dump(request)
     let response = try await coreNetwork.dataTask(request: request)
     return response
   }
@@ -38,7 +47,7 @@ struct BookmarkAPIClient: DependencyKey {
   func deleteMyPlace(placeId: Int) async throws -> HTTPURLResponse {
     let coreNetwork = CoreNetwork.shared
     var urlComponents = URLComponents(string: coreNetwork.baseURL)
-    urlComponents?.path = "/api/v1/members/me/places/\(placeId)"
+    urlComponents?.path = "/api/v1/places/\(placeId)/delete-from-folder"
     guard let request = urlComponents?.toURLRequest(method: .delete) else {
       throw CoreNetworkError.requestConvertFailed
     }

--- a/Projects/Coffice/Sources/App/Entities/Address.swift
+++ b/Projects/Coffice/Sources/App/Entities/Address.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Network
 
-public struct Address: Equatable {
+public struct Address: Hashable {
   public let address: String?
   public let postalCode: String?
 }

--- a/Projects/Coffice/Sources/App/Entities/Cafe.swift
+++ b/Projects/Coffice/Sources/App/Entities/Cafe.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Network
 
-struct Cafe: Equatable {
+struct Cafe: Hashable {
   static let dummy = Cafe(
     placeId: 0,
     name: "name",

--- a/Projects/Coffice/Sources/App/Entities/CrowdednessResponse.swift
+++ b/Projects/Coffice/Sources/App/Entities/CrowdednessResponse.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Network
 
-public struct CrowdednessResponse: Equatable {
+public struct CrowdednessResponse: Hashable {
   public let weekDayType: String?
   public let dayTimeType: String?
   public let crowdednessLevel: String?

--- a/Projects/Coffice/Sources/App/Entities/TimeOffset.swift
+++ b/Projects/Coffice/Sources/App/Entities/TimeOffset.swift
@@ -14,8 +14,9 @@ public struct TimeOffset: Equatable {
   public let minute: Int?
 }
 
-extension TimeOffsetDTO {
+extension String {
+  // TODO: String 형태로 내려오는 time을 변환하기
   func toEntity() -> TimeOffset {
-    return .init(hour: hour, minute: minute)
+    return .init(hour: 0, minute: 0)
   }
 }

--- a/Projects/Coffice/Sources/App/Main/SavedList/SavedListCoordinatorCore.swift
+++ b/Projects/Coffice/Sources/App/Main/SavedList/SavedListCoordinatorCore.swift
@@ -25,8 +25,16 @@ struct SavedListCoordinator: ReducerProtocol {
   }
 
   var body: some ReducerProtocolOf<SavedListCoordinator> {
-    Reduce<State, Action> { _, action in
+    Reduce<State, Action> { state, action in
       switch action {
+      case .routeAction(_, action: .savedList(.pushCafeDetail(let cafeId))):
+        state.routes.push(.cafeSearchDetail(.init(cafeId: cafeId)))
+        return .none
+
+      case .routeAction(_, action: .cafeSearchDetail(.popView)):
+        state.routes.pop()
+        return .none
+
       default:
         return .none
       }

--- a/Projects/Coffice/Sources/App/Main/SavedList/SavedListCoordinatorView.swift
+++ b/Projects/Coffice/Sources/App/Main/SavedList/SavedListCoordinatorView.swift
@@ -21,6 +21,12 @@ struct SavedListCoordinatorView: View {
           action: SavedListScreen.Action.savedList,
           then: SavedListView.init
         )
+
+        CaseLet(
+          state: /SavedListScreen.State.cafeSearchDetail,
+          action: SavedListScreen.Action.cafeSearchDetail,
+          then: CafeSearchDetailView.init
+        )
       }
     }
   }

--- a/Projects/Coffice/Sources/App/Main/SavedList/SavedListCore.swift
+++ b/Projects/Coffice/Sources/App/Main/SavedList/SavedListCore.swift
@@ -10,7 +10,7 @@ import ComposableArchitecture
 
 struct SavedList: ReducerProtocol {
   struct State: Equatable {
-    let title = "SavedList"
+    let title = "저장 리스트"
   }
 
   enum Action: Equatable {

--- a/Projects/Coffice/Sources/App/Main/SavedList/SavedListCore.swift
+++ b/Projects/Coffice/Sources/App/Main/SavedList/SavedListCore.swift
@@ -11,18 +11,37 @@ import ComposableArchitecture
 struct SavedList: ReducerProtocol {
   struct State: Equatable {
     let title = "저장 리스트"
+    var cafes: [Cafe] = []
   }
 
   enum Action: Equatable {
     case onAppear
+    case onDisappear
+    case bookmarkedCafeResponse(cafes: [Cafe])
+    case deleteCafefromBookmark(cafeId: Int)
   }
 
-  @Dependency(\.apiClient) private var apiClient
+  @Dependency(\.bookmarkClient) private var bookmarkClient
 
   var body: some ReducerProtocolOf<SavedList> {
-    Reduce { _, action in
+    Reduce { state, action in
       switch action {
       case .onAppear:
+        return .run { send in
+          let bookmarkedCafes = try await bookmarkClient.fetchMyPlaces()
+          await send(.bookmarkedCafeResponse(cafes: bookmarkedCafes))
+        } catch: { error, send in
+          debugPrint(error)
+        }
+
+      case .onDisappear:
+        return .none
+
+      case .bookmarkedCafeResponse(let cafes):
+        state.cafes = cafes
+        return .none
+
+      case .deleteCafefromBookmark(let cafeId):
         return .none
       }
     }

--- a/Projects/Coffice/Sources/App/Main/SavedList/SavedListCore.swift
+++ b/Projects/Coffice/Sources/App/Main/SavedList/SavedListCore.swift
@@ -29,6 +29,7 @@ struct SavedList: ReducerProtocol {
     case bookmarkButtonTapped(cafe: BookmarkCafe)
     case bookmarkedCafeResponse(cafes: [BookmarkCafe])
     case deleteCafesFromBookmark
+    case pushCafeDetail(cafeId: Int)
   }
 
   @Dependency(\.bookmarkClient) private var bookmarkClient
@@ -68,6 +69,9 @@ struct SavedList: ReducerProtocol {
         } catch: { error, send in
           debugPrint(error)
         }
+
+      case .pushCafeDetail(let cafeId):
+        return .none
       }
     }
   }

--- a/Projects/Coffice/Sources/App/Main/SavedList/SavedListCore.swift
+++ b/Projects/Coffice/Sources/App/Main/SavedList/SavedListCore.swift
@@ -20,6 +20,7 @@ struct SavedList: ReducerProtocol {
     var unBookmarkedCafeIds: [Int] {
       return cafes.filter { $0.isBookmarked.isFalse }.map { $0.cafeData.placeId }
     }
+    var didFetchComplete: Bool = false
   }
 
   enum Action: Equatable {
@@ -58,6 +59,7 @@ struct SavedList: ReducerProtocol {
 
       case .bookmarkedCafeResponse(let cafes):
         state.cafes = cafes
+        state.didFetchComplete = true
         return .none
 
       case .deleteCafesFromBookmark:

--- a/Projects/Coffice/Sources/App/Main/SavedList/SavedListCore.swift
+++ b/Projects/Coffice/Sources/App/Main/SavedList/SavedListCore.swift
@@ -21,6 +21,9 @@ struct SavedList: ReducerProtocol {
       return cafes.filter { $0.isBookmarked.isFalse }.map { $0.cafeData.placeId }
     }
     var didFetchComplete: Bool = false
+    var shouldShowEmptyListReplaceView: Bool {
+      return didFetchComplete && cafes.isEmpty
+    }
   }
 
   enum Action: Equatable {

--- a/Projects/Coffice/Sources/App/Main/SavedList/SavedListScreenCore.swift
+++ b/Projects/Coffice/Sources/App/Main/SavedList/SavedListScreenCore.swift
@@ -1,5 +1,5 @@
 //
-//  SearchScreenCore.swift
+//  SavedListScreenCore.swift
 //  Cafe
 //
 //  Created by MinKyeongTae on 2023/05/29.
@@ -9,29 +9,24 @@
 import ComposableArchitecture
 import TCACoordinators
 
-struct SearchScreen: ReducerProtocol {
+struct SavedListScreen: ReducerProtocol {
   enum State: Equatable {
     /// 메인 페이지
-    case cafeMap(CafeMapCore.State)
+    case savedList(SavedList.State)
     case cafeSearchDetail(CafeSearchDetail.State)
-    case cafeSearchList(CafeSearchListCore.State)
-    case cafeReviewWrite(CafeReviewWrite.State)
   }
 
   enum Action: Equatable {
-    case cafeMap(CafeMapCore.Action)
+    case savedList(SavedList.Action)
     case cafeSearchDetail(CafeSearchDetail.Action)
-    case cafeSearchList(CafeSearchListCore.Action)
-    case cafeReviewWrite(CafeReviewWrite.Action)
-    case popView
   }
 
-  var body: some ReducerProtocolOf<SearchScreen> {
+  var body: some ReducerProtocolOf<SavedListScreen> {
     Scope(
-      state: /State.cafeMap,
-      action: /Action.cafeMap
+      state: /State.savedList,
+      action: /Action.savedList
     ) {
-      CafeMapCore()
+      SavedList()
     }
 
     Scope(
@@ -39,20 +34,6 @@ struct SearchScreen: ReducerProtocol {
       action: /Action.cafeSearchDetail
     ) {
       CafeSearchDetail()
-    }
-
-    Scope(
-      state: /State.cafeSearchList,
-      action: /Action.cafeSearchList
-    ) {
-        CafeSearchListCore()
-    }
-
-    Scope(
-      state: /State.cafeReviewWrite,
-      action: /Action.cafeReviewWrite
-    ) {
-        CafeReviewWrite()
     }
   }
 }

--- a/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
+++ b/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
@@ -70,8 +70,8 @@ struct SavedListView: View {
                       viewStore.send(.bookmarkButtonTapped(cafe: cafe))
                     } label: {
                       (
-                        cafe.isBookmarked ?
-                        CofficeAsset.Asset.bookmarkFill40px.swiftUIImage
+                        cafe.isBookmarked
+                        ? CofficeAsset.Asset.bookmarkFill40px.swiftUIImage
                         : CofficeAsset.Asset.bookmarkLine40px.swiftUIImage
                       )
                       .resizable()

--- a/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
+++ b/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
@@ -41,22 +41,26 @@ struct SavedListView: View {
                   .cornerRadius(5)
                   .overlay(alignment: .topTrailing) {
                     Button {
-                      debugPrint("저장화면 bookmark tapped")
+                      viewStore.send(.bookmarkButtonTapped(cafe: cafe))
                     } label: {
-                      CofficeAsset.Asset.bookmarkLine40px.swiftUIImage
+                      (
+                        cafe.isBookmarked ?
+                        CofficeAsset.Asset.bookmarkFill40px.swiftUIImage
+                        : CofficeAsset.Asset.bookmarkLine40px.swiftUIImage
+                      )
                         .resizable()
                         .renderingMode(.template)
                         .foregroundColor(CofficeAsset.Colors.grayScale1.swiftUIColor)
                         .frame(width: 40, height: 40)
                     }
                   }
-                Text(cafe.name)
+                Text(cafe.cafeData.name)
                   .lineLimit(1)
                   .frame(maxWidth: .infinity, alignment: .leading)
                   .applyCofficeFont(font: .header3)
                   .foregroundColor(CofficeAsset.Colors.grayScale9.swiftUIColor)
                   .padding(.top, 16)
-                Text(cafe.address?.address ?? "")
+                Text(cafe.cafeData.address?.address ?? "")
                   .lineLimit(1)
                   .frame(maxWidth: .infinity, alignment: .leading)
                   .applyCofficeFont(font: .body2Medium)

--- a/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
+++ b/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
@@ -28,7 +28,7 @@ struct SavedListView: View {
             alignment: .center,
             spacing: 24
           ) {
-            ForEach((0...30), id: \.self) { _ in
+            ForEach(viewStore.cafes, id: \.self) { cafe in
               VStack(spacing: 0) {
                 CofficeAsset.Asset.cafeImage.swiftUIImage
                   .resizable()
@@ -50,12 +50,14 @@ struct SavedListView: View {
                         .frame(width: 40, height: 40)
                     }
                   }
-                Text("카페 이름")
+                Text(cafe.name)
+                  .lineLimit(1)
                   .frame(maxWidth: .infinity, alignment: .leading)
                   .applyCofficeFont(font: .header3)
                   .foregroundColor(CofficeAsset.Colors.grayScale9.swiftUIColor)
                   .padding(.top, 16)
-                Text("카페 주소")
+                Text(cafe.address?.address ?? "")
+                  .lineLimit(1)
                   .frame(maxWidth: .infinity, alignment: .leading)
                   .applyCofficeFont(font: .body2Medium)
                   .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
@@ -77,6 +79,9 @@ struct SavedListView: View {
             .padding(.vertical, 14)
           }
         }
+      }
+      .onAppear {
+        viewStore.send(.onAppear)
       }
     }
   }

--- a/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
+++ b/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
@@ -13,7 +13,33 @@ struct SavedListView: View {
   let store: StoreOf<SavedList>
 
   var body: some View {
-    mainView
+    WithViewStore(store) { viewStore in
+      Group {
+        if viewStore.state.cafes.isEmpty {
+          emptyListReplaceView
+        } else {
+          mainView
+        }
+      }
+      .onAppear {
+        viewStore.send(.onAppear)
+      }
+      .onDisappear {
+        viewStore.send(.onDisappear)
+      }
+      .customNavigationBar {
+        HStack(spacing: 4) {
+          Text(viewStore.title)
+            .applyCofficeFont(font: .header1)
+            .foregroundColor(CofficeAsset.Colors.grayScale9.swiftUIColor)
+          CofficeAsset.Asset.bookmarkFill40px.swiftUIImage
+            .frame(width: 36, height: 36)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.leading, 20)
+        .padding(.vertical, 14)
+      }
+    }
   }
 
   var mainView: some View {
@@ -70,28 +96,24 @@ struct SavedListView: View {
             }
           }
           .padding(.horizontal, 20)
-          .customNavigationBar {
-            HStack(spacing: 4) {
-              Text(viewStore.title)
-                .applyCofficeFont(font: .header1)
-                .foregroundColor(CofficeAsset.Colors.grayScale9.swiftUIColor)
-              CofficeAsset.Asset.bookmarkFill40px.swiftUIImage
-                .frame(width: 36, height: 36)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.leading, 20)
-            .padding(.vertical, 14)
-          }
         }
         .padding(.bottom, TabBarSizePreferenceKey.defaultValue.height)
       }
-      .onAppear {
-        viewStore.send(.onAppear)
-      }
-      .onDisappear {
-        viewStore.send(.onDisappear)
-      }
     }
+  }
+
+  private var emptyListReplaceView: some View {
+    VStack(alignment: .center) {
+      Text("아직 저장된 공간이 없어요")
+        .applyCofficeFont(font: .header2)
+        .foregroundColor(CofficeAsset.Colors.grayScale9.swiftUIColor)
+      Text("작업하고 싶은 공간을 저장해보세요")
+        .applyCofficeFont(font: .subtitle1Medium)
+        .foregroundColor(CofficeAsset.Colors.grayScale6.swiftUIColor)
+        .padding(.top, 12)
+    }
+    .frame(maxHeight: .infinity)
+    .padding(.bottom, TabBarSizePreferenceKey.defaultValue.height)
   }
 }
 

--- a/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
+++ b/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
@@ -93,6 +93,9 @@ struct SavedListView: View {
                   .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
                   .padding(.top, 4)
               }
+              .onTapGesture {
+                viewStore.send(.pushCafeDetail(cafeId: cafe.cafeData.placeId))
+              }
             }
           }
           .padding(.horizontal, 20)

--- a/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
+++ b/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
@@ -74,10 +74,11 @@ struct SavedListView: View {
                         CofficeAsset.Asset.bookmarkFill40px.swiftUIImage
                         : CofficeAsset.Asset.bookmarkLine40px.swiftUIImage
                       )
-                        .resizable()
-                        .renderingMode(.template)
-                        .foregroundColor(CofficeAsset.Colors.grayScale1.swiftUIColor)
-                        .frame(width: 40, height: 40)
+                      .resizable()
+                      .renderingMode(.template)
+                      .foregroundColor(CofficeAsset.Colors.grayScale1.swiftUIColor)
+                      .frame(width: 40, height: 40)
+                      .opacity(0.8)
                     }
                   }
                 Text(cafe.cafeData.name)

--- a/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
+++ b/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
@@ -15,7 +15,7 @@ struct SavedListView: View {
   var body: some View {
     WithViewStore(store) { viewStore in
       Group {
-        if viewStore.state.cafes.isEmpty {
+        if viewStore.state.didFetchComplete && viewStore.state.cafes.isEmpty {
           emptyListReplaceView
         } else {
           mainView

--- a/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
+++ b/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
@@ -18,14 +18,66 @@ struct SavedListView: View {
 
   var mainView: some View {
     WithViewStore(store) { viewStore in
-      VStack {
-        Spacer()
-        Text("SavedListView")
-        Spacer()
+      GeometryReader { proxy in
+        ScrollView(.vertical) {
+          LazyVGrid(
+            columns: [
+              GridItem(.flexible(), spacing: 20),
+              GridItem(.flexible(), spacing: 20)
+            ],
+            alignment: .center,
+            spacing: 24
+          ) {
+            ForEach((0...30), id: \.self) { _ in
+              VStack(spacing: 0) {
+                CofficeAsset.Asset.cafeImage.swiftUIImage
+                  .resizable()
+                  .aspectRatio(contentMode: .fill)
+                  .frame(
+                    width: (proxy.size.width - 60) / 2,
+                    height: (proxy.size.width - 60) / 2
+                  )
+                  .clipped()
+                  .cornerRadius(5)
+                  .overlay(alignment: .topTrailing) {
+                    Button {
+                      debugPrint("저장화면 bookmark tapped")
+                    } label: {
+                      CofficeAsset.Asset.bookmarkLine40px.swiftUIImage
+                        .resizable()
+                        .renderingMode(.template)
+                        .foregroundColor(CofficeAsset.Colors.grayScale1.swiftUIColor)
+                        .frame(width: 40, height: 40)
+                    }
+                  }
+                Text("카페 이름")
+                  .frame(maxWidth: .infinity, alignment: .leading)
+                  .applyCofficeFont(font: .header3)
+                  .foregroundColor(CofficeAsset.Colors.grayScale9.swiftUIColor)
+                  .padding(.top, 16)
+                Text("카페 주소")
+                  .frame(maxWidth: .infinity, alignment: .leading)
+                  .applyCofficeFont(font: .body2Medium)
+                  .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
+                  .padding(.top, 4)
+              }
+            }
+          }
+          .padding(.horizontal, 20)
+          .customNavigationBar {
+            HStack(spacing: 4) {
+              Text(viewStore.title)
+                .applyCofficeFont(font: .header1)
+                .foregroundColor(CofficeAsset.Colors.grayScale9.swiftUIColor)
+              CofficeAsset.Asset.bookmarkFill40px.swiftUIImage
+                .frame(width: 36, height: 36)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.leading, 20)
+            .padding(.vertical, 14)
+          }
+        }
       }
-      .customNavigationBar(centerView: {
-        Text(viewStore.title)
-      })
     }
   }
 }

--- a/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
+++ b/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
@@ -15,7 +15,7 @@ struct SavedListView: View {
   var body: some View {
     WithViewStore(store) { viewStore in
       Group {
-        if viewStore.state.didFetchComplete && viewStore.state.cafes.isEmpty {
+        if viewStore.shouldShowEmptyListReplaceView {
           emptyListReplaceView
         } else {
           mainView

--- a/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
+++ b/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
@@ -83,9 +83,13 @@ struct SavedListView: View {
             .padding(.vertical, 14)
           }
         }
+        .padding(.bottom, TabBarSizePreferenceKey.defaultValue.height)
       }
       .onAppear {
         viewStore.send(.onAppear)
+      }
+      .onDisappear {
+        viewStore.send(.onDisappear)
       }
     }
   }

--- a/Projects/Coffice/Sources/App/Main/Search/CafeMapCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeMapCore.swift
@@ -78,7 +78,7 @@ struct CafeMapCore: ReducerProtocol {
     case cafeListResponse(TaskResult<[CafeMarkerData]>)
 
     case filterOrderMenuClicked(FilterOrder)
-    case pushToSearchDetailForTest
+    case pushToSearchDetailForTest(cafeId: Int)
     case pushToSearchListForTest
 
     case requestLocationAuthorization
@@ -161,7 +161,7 @@ struct CafeMapCore: ReducerProtocol {
         case .searchList:
           return EffectTask(value: .pushToSearchListForTest)
         case .searchDetail:
-          return EffectTask(value: .pushToSearchDetailForTest)
+          return EffectTask(value: .pushToSearchDetailForTest(cafeId: 1))
         default:
           return .none
         }

--- a/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailCore.swift
@@ -12,6 +12,7 @@ import Foundation
 struct CafeSearchDetail: ReducerProtocol {
   struct State: Equatable {
     let title = "CafeSearchDetail"
+    var cafeId: Int
     var cafe: Cafe?
 
     let subMenuTypes = SubMenuType.allCases
@@ -63,8 +64,8 @@ struct CafeSearchDetail: ReducerProtocol {
     Reduce { state, action in
       switch action {
       case .onAppear:
-        return .run { send in
-          let cafe = try await placeAPIClient.fetchPlace(placeId: 1)
+        return .run { [cafeId = state.cafeId] send in
+          let cafe = try await placeAPIClient.fetchPlace(placeId: cafeId)
           await send(.placeResponse(cafe: cafe))
         } catch: { error, send in
           debugPrint(error)

--- a/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailMenuView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailMenuView.swift
@@ -414,7 +414,7 @@ struct CafeSearchDetailMenuView_Previews: PreviewProvider {
   static var previews: some View {
     CafeSearchDetailMenuView(
       store: .init(
-        initialState: .init(),
+        initialState: .init(cafeId: 1),
         reducer: CafeSearchDetail()
       )
     )

--- a/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailSubInfoView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailSubInfoView.swift
@@ -137,7 +137,7 @@ struct CafeSearchDetailSubInfoView_Previews: PreviewProvider {
   static var previews: some View {
     CafeSearchDetailSubInfoView(
       store: .init(
-        initialState: .init(),
+        initialState: .init(cafeId: 1),
         reducer: CafeSearchDetail()
       )
     )

--- a/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailView.swift
@@ -62,7 +62,7 @@ struct CafeSearchDetailView_Previews: PreviewProvider {
   static var previews: some View {
     CafeSearchDetailView(
       store: .init(
-        initialState: .init(),
+        initialState: .init(cafeId: 1),
         reducer: CafeSearchDetail()
       )
     )

--- a/Projects/Coffice/Sources/App/Main/Search/SearchCoordinatorCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/SearchCoordinatorCore.swift
@@ -44,8 +44,8 @@ struct SearchCoordinator: ReducerProtocol {
         state.routes.pop()
         return .none
 
-      case .routeAction(_, action: .cafeMap(.pushToSearchDetailForTest)):
-        state.routes.push(.cafeSearchDetail(.init()))
+      case .routeAction(_, action: .cafeMap(.pushToSearchDetailForTest(let cafeId))):
+        state.routes.push(.cafeSearchDetail(.init(cafeId: cafeId)))
         return .none
 
       case .routeAction(_, action: .cafeSearchDetail(.popView)):

--- a/Projects/Coffice/Sources/App/Main/Search/SearchScreenCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/SearchScreenCore.swift
@@ -1,5 +1,5 @@
 //
-//  SavedListScreenCore.swift
+//  SearchScreenCore.swift
 //  Cafe
 //
 //  Created by MinKyeongTae on 2023/05/29.
@@ -9,22 +9,50 @@
 import ComposableArchitecture
 import TCACoordinators
 
-struct SavedListScreen: ReducerProtocol {
+struct SearchScreen: ReducerProtocol {
   enum State: Equatable {
     /// 메인 페이지
-    case savedList(SavedList.State)
+    case cafeMap(CafeMapCore.State)
+    case cafeSearchDetail(CafeSearchDetail.State)
+    case cafeSearchList(CafeSearchListCore.State)
+    case cafeReviewWrite(CafeReviewWrite.State)
   }
 
   enum Action: Equatable {
-    case savedList(SavedList.Action)
+    case cafeMap(CafeMapCore.Action)
+    case cafeSearchDetail(CafeSearchDetail.Action)
+    case cafeSearchList(CafeSearchListCore.Action)
+    case cafeReviewWrite(CafeReviewWrite.Action)
+    case popView
   }
 
-  var body: some ReducerProtocolOf<SavedListScreen> {
+  var body: some ReducerProtocolOf<SearchScreen> {
     Scope(
-      state: /State.savedList,
-      action: /Action.savedList
+      state: /State.cafeMap,
+      action: /Action.cafeMap
     ) {
-      SavedList()
+      CafeMapCore()
+    }
+
+    Scope(
+      state: /State.cafeSearchDetail,
+      action: /Action.cafeSearchDetail
+    ) {
+      CafeSearchDetail()
+    }
+
+    Scope(
+      state: /State.cafeSearchList,
+      action: /Action.cafeSearchList
+    ) {
+        CafeSearchListCore()
+    }
+
+    Scope(
+      state: /State.cafeReviewWrite,
+      action: /Action.cafeReviewWrite
+    ) {
+        CafeReviewWrite()
     }
   }
 }

--- a/Projects/Network/Sources/DTOs/Requests/SaveToFolderRequestDTO.swift
+++ b/Projects/Network/Sources/DTOs/Requests/SaveToFolderRequestDTO.swift
@@ -9,9 +9,9 @@
 import Foundation
 
 public struct SavePlacesRequestDTO: Encodable {
-  public let placeIds: [Int]
+  public let postIds: [Int]
 
-  public init(placeIds: [Int]) {
-    self.placeIds = placeIds
+  public init(postIds: [Int]) {
+    self.postIds = postIds
   }
 }

--- a/Projects/Network/Sources/DTOs/Requests/SaveToFolderRequestDTO.swift
+++ b/Projects/Network/Sources/DTOs/Requests/SaveToFolderRequestDTO.swift
@@ -8,10 +8,10 @@
 
 import Foundation
 
-public struct SaveToFolderRequestDTO: Encodable {
-  public let placeFolderId: Int
+public struct SavePlacesRequestDTO: Encodable {
+  public let placeIds: [Int]
 
-  public init(placeFolderId: Int) {
-    self.placeFolderId = placeFolderId
+  public init(placeIds: [Int]) {
+    self.placeIds = placeIds
   }
 }

--- a/Projects/Network/Sources/DTOs/Requests/SaveToFolderRequestDTO.swift
+++ b/Projects/Network/Sources/DTOs/Requests/SaveToFolderRequestDTO.swift
@@ -1,0 +1,17 @@
+//
+//  SaveToFolderRequestDTO.swift
+//  Network
+//
+//  Created by 천수현 on 2023/07/03.
+//  Copyright © 2023 kr.co.yapp. All rights reserved.
+//
+
+import Foundation
+
+public struct SaveToFolderRequestDTO: Encodable {
+  public let placeFolderId: Int
+
+  public init(placeFolderId: Int) {
+    self.placeFolderId = placeFolderId
+  }
+}

--- a/Projects/Network/Sources/DTOs/Responses/SearchPlaceResponseDTO.swift
+++ b/Projects/Network/Sources/DTOs/Responses/SearchPlaceResponseDTO.swift
@@ -30,13 +30,8 @@ public struct SearchPlaceResponseDTO: Decodable {
 public struct OpeningHourResponseDTO: Decodable {
   public let dayOfWeek: String?
   public let openingHourType: String?
-  public let openedAt: TimeOffsetDTO?
-  public let closedAt: TimeOffsetDTO?
-}
-
-public struct TimeOffsetDTO: Decodable {
-  public let hour: Int?
-  public let minute: Int?
+  public let openedAt: String?
+  public let closedAt: String?
 }
 
 public struct CrowdednessResponseDTO: Decodable {


### PR DESCRIPTION
## ☕️ PR 요약
- color grayscale8에 대한 변경사항 반영완료
- 저장탭 UI 구현
- 저장된 카페 탭시 카페 상세화면으로 이동하는 플로우 제작
- 카페 상세화면으로 이동할때 placeId (cafeId)를 받아 해당 카페를 fetch하는 로직 제작
- 저장된 카페 상세화면 진입 후 뒤로가기 버튼 탭시 popView 되도록 동작 구현
- cafeCell 목록을 ForEach로 순회할때 index가 아닌 해당 위치의 instance 기반으로 사용할 수 있도록 Cafe관련 Entity에 Hashable 채택
- SavedList와 Search의 ScreenCore가 파일명, 위치가 뒤바뀌어 있던 것 수정
- TimeOffset 대신 String으로 openedAt, closedAt 파싱하도록 변경 

### 참고사항
~~북마크 해제된 카페 일괄삭제 API는 서버에서 리뷰중이므로 배포 이후에 동작 예정입니다.~~
배포 완료되어 반영 완료했습니다.

## 📸 ScreenShot
![Simulator Screen Recording - iPhone 14 Pro - 2023-07-04 at 22 39 45](https://github.com/YAPP-Github/Coffice-iOS/assets/67148595/26f563ed-7029-41fc-8b2f-2728e82f7df3)


#### Linked Issue

close #94 
