### PR TITLE
[Fix] #95 개발자 테스트화면 TextField 바인딩 이벤트 2번씩 발생하는 문제 수정

### DIFF
--- a/Projects/Coffice/Sources/App/Main/MyPage/DevTestView.swift
+++ b/Projects/Coffice/Sources/App/Main/MyPage/DevTestView.swift
@@ -45,6 +45,7 @@ extension DevTestView {
         "textField with BindingState",
         text: viewStore.binding(\.$textFieldStringWithBindingState)
       )
+      .textFieldStyle(.plain)
       .frame(height: 35)
       .padding(.horizontal, 5)
       .padding(.trailing, 25)
@@ -65,6 +66,7 @@ extension DevTestView {
           send: DevTest.Action.textFieldStringDidChange
         )
       )
+      .textFieldStyle(.plain)
       .frame(height: 35)
       .padding(.horizontal, 5)
       .padding(.trailing, 25)


### PR DESCRIPTION
## ☕️ PR 요약
- 개발자 테스트화면 TextField 바인딩 이벤트 2번씩 발생하는 문제 수정
- textFieldStyle을 plain으로 설정하지 않으면, 바인딩이벤트가 2번씩 발생하는 문제가 있었는데, 리뷰작성화면, 검색화면은 수정했으나, 마저 수정하지 못한 개발자 테스트화면 TextField 의 바인딩이벤트 문제를 수정했습니다.

##### ✅ PR check list(PR 요청시 확인후 삭제해주세요)

```
- commit message가 적절한지 확인해주세요.
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```



#### Linked Issue

close #95 
