### PR TITLE
[Fix] #106 카페 검색 상세화면 스크롤영역 하단 일부가 잘리는 현상 수정

### DIFF
--- a/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailView.swift
@@ -29,7 +29,11 @@ struct CafeSearchDetailView: View {
             CafeSearchDetailSubInfoView(store: store)
             CafeSearchDetailMenuView(store: store)
           }
-          .padding(.bottom, 50)
+          .padding(
+            .bottom,
+            TabBarSizePreferenceKey.defaultValue.height
+            + (UIApplication.keyWindow?.safeAreaInsets.bottom ?? 0.0)
+          )
         }
       }
       .navigationBarHidden(true)


### PR DESCRIPTION
## ☕️ PR 요약
- 카페검색 상세화면 하단 일부가 잘리는 문제를 수정했습니다.
  - safe area bottom inset + 탭바 높이를 padding값으로 설정해서 일부 컨텐츠가 잘리지 않도록 수정
[Issue 페이지](https://github.com/YAPP-Github/Coffice-iOS/issues/106)에 to-be 이미지를 첨부했습니다.


##### ✅ PR check list(PR 요청시 확인후 삭제해주세요)

```
- commit message가 적절한지 확인해주세요.
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```



#### Linked Issue

close #106 
