### PR TITLE
[Chore] #37 검색 메인화면 상단에 필터뷰 UI, 이벤트 연결

### DIFF
--- a/Projects/Coffice/Sources/App/Main/MainCoordinatorCore.swift
+++ b/Projects/Coffice/Sources/App/Main/MainCoordinatorCore.swift
@@ -82,14 +82,14 @@ struct MainCoordinator: ReducerProtocol {
       case .filterBottomSheet(.saveCafeFilter(let information)):
         return EffectTask(
           value: .search(
-            .routeAction(1, action: .cafeSearchList(.updateCafeFilter(information: information)))
+            .routeAction(0, action: .cafeMap(.updateCafeFilter(information: information)))
           )
         )
 
       case .filterBottomSheet(.dismissWithDelay):
         return EffectTask(
           value: .search(
-            .routeAction(1, action: .cafeSearchList(.filterBottomSheetDismissed))
+            .routeAction(0, action: .cafeMap(.filterBottomSheetDismissed))
           )
         )
 
@@ -101,7 +101,7 @@ struct MainCoordinator: ReducerProtocol {
         return .none
 
       case .search(
-        .routeAction(_, .cafeSearchList(.filterMenus(action: .presentFilterBottomSheetView(let filterSheetState))))
+        .routeAction(_, .cafeMap(.cafeFilterMenus(action: .presentFilterBottomSheetView(let filterSheetState))))
       ):
         state.filterSheetState = filterSheetState
         return .none

--- a/Projects/Coffice/Sources/App/Main/Search/CafeFilterMenusView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeFilterMenusView.swift
@@ -41,18 +41,20 @@ struct CafeFilterMenusView: View {
                         .stroke(viewState.borderColorAsset.swiftUIColor, lineWidth: 1)
                     )
                 default:
-                  HStack(alignment: .center, spacing: 0) {
+                  HStack(spacing: 0) {
                     Text(viewState.menuType.title)
                       .foregroundColor(viewState.foregroundColorAsset.swiftUIColor)
                       .applyCofficeFont(font: .body1Medium)
-                    Image(asset: CofficeAsset.Asset.arrowDropDownLine18px)
+                    CofficeAsset.Asset.arrowDropDownLine18px.swiftUIImage
                       .resizable()
                       .renderingMode(.template)
                       .frame(width: 18, height: 18)
                       .foregroundColor(viewState.foregroundColorAsset.swiftUIColor)
                   }
-                  .frame(width: viewState.menuType.size.width, height: viewState.menuType.size.height)
-                  .cornerRadius(16)
+                  .frame(height: viewState.menuType.size.height)
+                  .padding(.leading, 16)
+                  .padding(.trailing, 8)
+                  .cornerRadius(18)
                   .background(viewState.backgroundColorAsset.swiftUIColor.clipShape(Capsule()))
                   .overlay(
                     RoundedRectangle(cornerRadius: 18)
@@ -63,9 +65,9 @@ struct CafeFilterMenusView: View {
               .cornerRadius(18)
             }
           }
+          .padding(.horizontal, 20)
         }
         .frame(width: 355, height: 36)
-        .padding(.horizontal, 20)
         .padding(.bottom, 16)
       }
       .onAppear {

--- a/Projects/Coffice/Sources/App/Main/Search/CafeMapView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeMapView.swift
@@ -142,28 +142,12 @@ extension CafeMapView {
   }
 
   var orderFilterView: some View {
-    WithViewStore(store) { viewStore in
-      ScrollView(.horizontal, showsIndicators: false) {
-        HStack(spacing: 8) {
-          ForEach(viewStore.filterOrders, id: \.self) { order in
-            Button {
-              viewStore.send(.filterOrderMenuTapped(order))
-            } label: {
-              Text(order.title)
-                .font(.subheadline)
-                .foregroundColor(.black)
-                .lineLimit(1)
-                .padding(EdgeInsets(top: 7, leading: 12, bottom: 7, trailing: 12))
-                .overlay {
-                  RoundedRectangle(cornerRadius: 20)
-                    .stroke(.gray, lineWidth: 1)
-                }
-                .frame(height: 60)
-            }
-          }
-        }
-        .padding(.horizontal, 16)
-      }
-    }
+    CafeFilterMenusView(
+      store: store.scope(
+        state: \.cafeFilterMenusState,
+        action: CafeMapCore.Action.cafeFilterMenus(action:)
+      )
+    )
+    .padding(.top, 16)
   }
 }

--- a/Projects/Coffice/Sources/App/Main/Search/CafeMapView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeMapView.swift
@@ -50,7 +50,7 @@ struct CafeMapView: View {
               .zIndex(1)
             }
             VStack(alignment: .trailing, spacing: 0) {
-              header
+              headerView
                 .onTapGesture { viewStore.send(.updateDisplayType(.searchView)) }
                 .background(CofficeAsset.Colors.grayScale1.swiftUIColor)
               floatingButtonView
@@ -99,45 +99,28 @@ extension CafeMapView {
     }
   }
 
-  var header: some View {
+  var headerView: some View {
     WithViewStore(store) { viewStore in
       VStack(spacing: 0) {
-        searchTextField
+        searchDescriptionView
         orderFilterView
       }
     }
   }
 
-  var searchTextField: some View {
+  var searchDescriptionView: some View {
     WithViewStore(store) { viewStore in
-      ZStack {
-        TextField(
-          "🔍  지역, 지하철로 검색",
-          text: viewStore.binding(\.$searchText)
-        )
-        .textFieldStyle(.plain)
-        .applyCofficeFont(font: .subtitle1Medium)
-        .frame(height: 35)
-        .padding(.leading, 5)
-        .padding(.trailing, 25)
-        .overlay {
-          RoundedRectangle(cornerRadius: 5)
-            .stroke(.gray, lineWidth: 1)
-        }
-        .onSubmit {
-        }
-
-        HStack {
-          Spacer()
-          Button {
-          } label: {
-            Image(systemName: "xmark.circle.fill")
-              .foregroundColor(.gray)
-              .padding(.trailing, 5)
-          }
-        }
+      HStack(spacing: 12) {
+        CofficeAsset.Asset.searchLine24px.swiftUIImage
+          .padding(.vertical, 12)
+        Text("지하철, 카페 이름으로 검색")
+          .foregroundColor(CofficeAsset.Colors.grayScale6.swiftUIColor)
+          .applyCofficeFont(font: .subtitle1Medium)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .frame(height: 20)
+          .padding(.vertical, 14)
       }
-      .padding(.horizontal, 16)
+      .padding(.horizontal, 20)
     }
   }
 
@@ -148,6 +131,6 @@ extension CafeMapView {
         action: CafeMapCore.Action.cafeFilterMenus(action:)
       )
     )
-    .padding(.top, 16)
+    .padding(.top, 8)
   }
 }


### PR DESCRIPTION
## ☕️ PR 요약
- 앞서 재사용을 위해 분리했던 CafeFilterMenus Reducer를 메인 검색화면에 연결했습니다.
+ 검색 메인화면 상단 헤더뷰 UI를 디자인가이드에 맞게 수정했습니다.



## 📸 ScreenShot
- 검색 메인화면 상단 필터뷰 적용 | 검색 메인화면 상단 헤더뷰 UI 수정
<div>
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/750441be-f76b-4662-a7fa-d93b340d6f29" width="200">
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/8cb8c755-4618-4868-bc7c-7062957d4704" width="200">
</div>

<br>
<br>

- 상단 필터버튼 좌우 padding 디자인가이드에 맞게 추가 수정했습니다.
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/c0cdada2-2495-4596-86c4-ccab61ad8c35" width="200">



##### ✅ PR check list(PR 요청시 확인후 삭제해주세요)

```
- commit message가 적절한지 확인해주세요.
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```



#### Linked Issue

resolved #37 
related #90 #32 
