### PR TITLE
[Feat] #115 #116 카페상세 테스트용 진입점 수정, 말풍선 가이드 메세지 표출 로직 구성 (#37 PR merge 선행 필요)

### DIFF
--- a/Projects/Coffice/Sources/App/Main/BubbleMessageCore.swift
+++ b/Projects/Coffice/Sources/App/Main/BubbleMessageCore.swift
@@ -11,9 +11,44 @@ import Foundation
 
 struct BubbleMessage: ReducerProtocol {
   struct State: Equatable {
-    let title: String
-    let subTitle: String
-    let subInfoViewStates: [SubInfoViewState]
+    let guideType: CafeFilter.GuideType
+
+    var title: String {
+      switch guideType {
+      case .outletState: return "콘센트"
+      case .spaceSize: return "공간크기"
+      case .groupSeat: return "단체석"
+      }
+    }
+
+    var subTitle: String {
+      switch guideType {
+      case .outletState: return "좌석대비 콘센트 비율"
+      case .spaceSize: return "테이블 기준 크기"
+      case .groupSeat: return "단체석 기준"
+      }
+    }
+
+    var subInfoViewStates: [SubInfoViewState] {
+      switch guideType {
+      case .outletState:
+        return [
+          .init(iconImage: CofficeAsset.Asset.close40px, title: "넉넉:", description: "80% 이상"),
+          .init(iconImage: CofficeAsset.Asset.close40px, title: "보통:", description: "30% ~ 80%"),
+          .init(iconImage: CofficeAsset.Asset.close40px, title: "부족:", description: "30% 미만")
+        ]
+      case .spaceSize:
+        return [
+          .init(iconImage: CofficeAsset.Asset.close40px, title: "대형:", description: "테이블 15개 이상"),
+          .init(iconImage: CofficeAsset.Asset.close40px, title: "보통:", description: "테이블 6 ~ 14개"),
+          .init(iconImage: CofficeAsset.Asset.close40px, title: "부족:", description: "테이블 5개 이하")
+        ]
+      case .groupSeat:
+        return [
+          .init(iconImage: CofficeAsset.Asset.close40px, title: "단체석:", description: "5인 테이블")
+        ]
+      }
+    }
   }
 
   struct SubInfoViewState: Equatable, Identifiable {
@@ -39,14 +74,6 @@ struct BubbleMessage: ReducerProtocol {
 
 extension BubbleMessage.State {
   static var mock: Self {
-    .init(
-      title: "콘센트",
-      subTitle: "좌석대비 콘센트 비율",
-      subInfoViewStates: [
-        .init(iconImage: CofficeAsset.Asset.close40px, title: "넉넉:", description: "80% 이상"),
-        .init(iconImage: CofficeAsset.Asset.close40px, title: "보통:", description: "30% ~ 80%"),
-        .init(iconImage: CofficeAsset.Asset.close40px, title: "부족:", description: "30% 미만")
-      ]
-    )
+    .init(guideType: .outletState)
   }
 }

--- a/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheet.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheet.swift
@@ -19,6 +19,23 @@ struct CafeFilterBottomSheet: ReducerProtocol {
     }
 
     let filterType: CafeFilter.MenuType
+    var guideType: CafeFilter.GuideType? {
+      switch filterType {
+      case .outlet:
+        return .outletState
+      case .spaceSize:
+        return .spaceSize
+      case .personnel:
+        return .groupSeat
+      default:
+        return nil
+      }
+    }
+
+    var shouldShowGuideButton: Bool {
+      return guideType != nil
+    }
+
     /// 기존 필터 설정 상태
     var originCafeFilterInformation: CafeFilterInformation
     var cafeFilterInformation: CafeFilterInformation
@@ -121,8 +138,14 @@ struct CafeFilterBottomSheet: ReducerProtocol {
         return EffectTask(value: .updateMainViewState)
 
       case .infoGuideButtonTapped:
-        // TODO: 상세 필터 타입에 맞게 말풍선뷰 표출 필요
-        return EffectTask(value: .presentBubbleMessageView(.mock))
+        guard let guideType = state.guideType
+        else { return .none }
+
+        return EffectTask(
+          value: .presentBubbleMessageView(
+            .init(guideType: guideType)
+          )
+        )
 
       case .updateMainViewState:
         state.updateMainViewState()

--- a/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheetView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheetView.swift
@@ -73,9 +73,7 @@ extension CafeFilterBottomSheetView {
             CofficeAsset.Asset.informationLine18px.swiftUIImage
               .renderingMode(.template)
               .foregroundColor(CofficeAsset.Colors.grayScale6.swiftUIColor)
-              .padding(.top, 35)
-              .padding(.leading, 8)
-              .padding(.bottom, 27)
+              .padding(EdgeInsets(top: 35, leading: 8, bottom: 27, trailing: 0))
           }
         }
 

--- a/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheetView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheetView.swift
@@ -66,15 +66,17 @@ extension CafeFilterBottomSheetView {
           .frame(height: 32)
           .padding(.top, 28)
           .padding(.bottom, 20)
-        Button {
-          viewStore.send(.infoGuideButtonTapped)
-        } label: {
-          CofficeAsset.Asset.informationLine18px.swiftUIImage
-            .renderingMode(.template)
-            .foregroundColor(CofficeAsset.Colors.grayScale6.swiftUIColor)
-            .padding(.top, 35)
-            .padding(.leading, 8)
-            .padding(.bottom, 27)
+        if viewStore.shouldShowGuideButton {
+          Button {
+            viewStore.send(.infoGuideButtonTapped)
+          } label: {
+            CofficeAsset.Asset.informationLine18px.swiftUIImage
+              .renderingMode(.template)
+              .foregroundColor(CofficeAsset.Colors.grayScale6.swiftUIColor)
+              .padding(.top, 35)
+              .padding(.leading, 8)
+              .padding(.bottom, 27)
+          }
         }
 
         Spacer()

--- a/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheetViewState.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheetViewState.swift
@@ -113,6 +113,12 @@ enum CafeFilter {
     }
   }
 
+  enum GuideType {
+    case outletState
+    case spaceSize
+    case groupSeat
+  }
+
   enum MenuType: CaseIterable {
     case detail
     case runningTime

--- a/Projects/Coffice/Sources/App/Main/Search/CafeMapView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeMapView.swift
@@ -32,12 +32,13 @@ struct CafeMapView: View {
                 if viewStore.selectedCafe != nil {
                   VStack {
                     Spacer()
+
                     CafeCardView(store: store)
                       .frame(width: geometry.size.width, height: 260)
                       .padding(.bottom, TabBarSizePreferenceKey.defaultValue.height)
                   }
                 } else {
-                  EmptyView()
+                  floatingTestButtonView
                 }
               }
 
@@ -95,6 +96,34 @@ extension CafeMapView {
           }
           .buttonStyle(.plain)
         }
+      }
+    }
+  }
+
+  @available(*, deprecated, message: "테스트용 UI로, 상제 리스트뷰 진입점 추가 후 제거 예정")
+  var floatingTestButtonView: some View {
+    WithViewStore(store) { viewStore in
+      VStack {
+        Spacer()
+
+        HStack {
+          Button {
+            viewStore.send(.pushToSearchDetailForTest(cafeId: 1))
+          } label: {
+            ZStack(alignment: .center) {
+              Circle()
+                .foregroundColor(.white)
+                .shadow(color: .gray, radius: 2, x: 0, y: 2)
+                .frame(width: 48, height: 48)
+              Text("검색상세")
+                .applyCofficeFont(font: .button)
+            }
+          }
+          .buttonStyle(.plain)
+          Spacer()
+        }
+        .padding(.leading, 24)
+        .padding(.bottom, TabBarSizePreferenceKey.defaultValue.height + 24)
       }
     }
   }

--- a/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailCore.swift
@@ -53,7 +53,7 @@ struct CafeSearchDetail: ReducerProtocol {
     case popView
     case subMenuTapped(State.SubMenuType)
     case toggleToPresentTextForTest
-    case infoGuideButtonTapped
+    case infoGuideButtonTapped(CafeFilter.GuideType)
     case presentBubbleMessageView(BubbleMessage.State)
     case presentCafeReviewWriteView
   }
@@ -89,9 +89,12 @@ struct CafeSearchDetail: ReducerProtocol {
         }
         return .none
 
-      case .infoGuideButtonTapped:
-        // TODO: 선택한 버튼에 맞게 맞춤형 정보가 있는 말풍선 표출 필요
-        return EffectTask(value: .presentBubbleMessageView(.mock))
+      case .infoGuideButtonTapped(let guideType):
+        return EffectTask(
+          value: .presentBubbleMessageView(
+            .init(guideType: guideType)
+          )
+        )
 
       default:
         return .none
@@ -189,6 +192,14 @@ extension CafeSearchDetail.State {
       case .outletState: return "power"
       case .spaceSize: return "house"
       case .groupSeat: return "person"
+      }
+    }
+
+    var guideType: CafeFilter.GuideType {
+      switch type {
+      case .outletState: return .outletState
+      case .spaceSize: return .spaceSize
+      case .groupSeat: return .groupSeat
       }
     }
   }

--- a/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailSubInfoView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailSubInfoView.swift
@@ -52,7 +52,7 @@ extension CafeSearchDetailSubInfoView {
                 .frame(width: 30, height: 30)
                 .overlay(alignment: .topTrailing) {
                   Button {
-                    viewStore.send(.infoGuideButtonTapped)
+                    viewStore.send(.infoGuideButtonTapped(viewState.guideType))
                   } label: {
                     Image(asset: CofficeAsset.Asset.informationLine18px)
                       .resizable()

--- a/Projects/Coffice/Sources/App/PreferenceKeys/TabBarSizePreferenceKey.swift
+++ b/Projects/Coffice/Sources/App/PreferenceKeys/TabBarSizePreferenceKey.swift
@@ -10,7 +10,7 @@ import Foundation
 import SwiftUI
 
 struct TabBarSizePreferenceKey: PreferenceKey {
-  static var defaultValue: CGSize = .zero
+  static var defaultValue: CGSize = .init(width: UIScreen.main.bounds.width, height: 65)
   static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
     value = nextValue()
   }


### PR DESCRIPTION
## ☕️ PR 요약
- 각 가이드 버튼을 선택했을때 말풍선에 알맞는 설명문구가 나오도록 하는 기능을 추가했습니다. (검색화면, 카페상세화면)
  - 검색 상단 필터뷰 변경 후, 카페 상세 테스트용 진입을 위해 검색 메인화면 좌하단에 테스트 floating 버튼을 추가했습니다. (#116)



## 📸 ScreenShot
<div>
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/5296db50-0134-4043-b045-4a53fff8eca8" width="200">
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/f4c08ea0-a8bf-4898-93eb-82f6b1f4d32f" width="200">
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/113b06ff-c98e-401f-a3eb-58a7c8227bba" width="200">
</div>


##### ✅ PR check list(PR 요청시 확인후 삭제해주세요)

```
- commit message가 적절한지 확인해주세요.
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```



#### Linked Issue

close #115 #116 
