### PR TITLE
[UI] #119 카페 상세화면 UI 디자인가이드 적용

### DIFF
--- a/Projects/Coffice/Sources/App/Main/MyPage/EditProfile/EditProfileView.swift
+++ b/Projects/Coffice/Sources/App/Main/MyPage/EditProfile/EditProfileView.swift
@@ -59,7 +59,7 @@ struct EditProfileView: View {
               "닉네임을 입력해주세요",
               text: viewStore.binding(\.$nicknameTextField)
             )
-            .applyCofficeFontForTextField(font: .subtitle1Medium)
+            .applyCofficeFontWithoutLineSpacing(font: .subtitle1Medium)
             .keyboardType(.default)
             .textFieldStyle(.plain)
             .padding(20)

--- a/Projects/Coffice/Sources/App/Main/Search/CafeSearchView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeSearchView.swift
@@ -59,7 +59,7 @@ extension CafeSearchView {
             .scaledToFit()
             .padding(.trailing, 12)
           TextField("지하철, 카페 이름으로 검색", text: viewStore.binding(\.$searchText))
-            .applyCofficeFontForTextField(font: .subtitle1Medium)
+            .applyCofficeFontWithoutLineSpacing(font: .subtitle1Medium)
             .tint(CofficeAsset.Colors.grayScale9.swiftUIColor)
             .foregroundColor(CofficeAsset.Colors.grayScale9.swiftUIColor)
             .onSubmit { viewStore.send(.submitText) }

--- a/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailCore.swift
@@ -144,22 +144,11 @@ extension CafeSearchDetail.State {
     var title: String {
       switch self {
       case .enoughOutlets:
-        return "콘센트 넉넉해요"
+        return "🔌 콘센트 넉넉해요"
       case .fastWifi:
-        return "와이파이 빨라요"
+        return "📶 와이파이 빨라요"
       case .quiet:
-        return "조용해요"
-      }
-    }
-
-    var iconName: String {
-      switch self {
-      case .enoughOutlets:
-        return "power"
-      case .fastWifi:
-        return "wifi"
-      case .quiet:
-        return "speaker.wave.1"
+        return "🔊 조용해요"
       }
     }
   }

--- a/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailCore.swift
@@ -45,6 +45,11 @@ struct CafeSearchDetail: ReducerProtocol {
                               """
     var runningTimeDetailInfo = ""
     var needToPresentRunningTimeDetailInfo = false
+    var runningTimeDetailInfoArrowImageAsset: CofficeImages {
+      return needToPresentRunningTimeDetailInfo
+      ? CofficeAsset.Asset.arrowDropUpLine24px
+      : CofficeAsset.Asset.arrowDropDownLine24px
+    }
   }
 
   enum Action: Equatable {
@@ -253,6 +258,13 @@ extension CafeSearchDetail.State {
     let id = UUID()
     let type: SubMenuType
     let isSelected: Bool
+    var foregroundColorAsset: CofficeColors {
+      isSelected ? CofficeAsset.Colors.grayScale9 : CofficeAsset.Colors.grayScale5
+    }
+
+    var bottomBorderColorAsset: CofficeColors {
+      isSelected ? CofficeAsset.Colors.grayScale9 : CofficeAsset.Colors.grayScale1
+    }
 
     init(subMenuType: SubMenuType, isSelected: Bool = false) {
       self.type = subMenuType

--- a/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailHeaderView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailHeaderView.swift
@@ -37,40 +37,39 @@ struct CafeSearchDetailHeaderView: View {
           HStack {
             VStack(spacing: 0) {
               Text("카페")
-                .foregroundColor(.black)
-                .font(.system(size: 14, weight: .bold))
+                .foregroundColor(CofficeAsset.Colors.grayScale9.swiftUIColor)
+                .applyCofficeFont(font: .button)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.top, 20)
+                .frame(height: 20)
               Text(viewStore.cafe?.name ?? "훅스턴")
-                .foregroundColor(.black)
-                .font(.system(size: 26, weight: .bold))
+                .foregroundColor(CofficeAsset.Colors.grayScale9.swiftUIColor)
+                .applyCofficeFont(font: .header0)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .frame(height: 36)
                 .padding(.top, 8)
               Text(viewStore.cafe?.address?.address ?? "서울 서대문구 연희로 91 2층")
-                .foregroundColor(.gray)
+                .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
+                .applyCofficeFont(font: .body1Medium)
                 .font(.system(size: 14))
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(height: 20)
                 .padding(.top, 4)
             }
 
             VStack {
-              CofficeAsset.Asset.bookmarkLine24px.swiftUIImage
-                .resizable()
-                .frame(width: 20, height: 24)
-                .padding(.top, 10)
+              CofficeAsset.Asset.bookmarkLine40px.swiftUIImage
               Spacer()
             }
           }
 
           HStack(spacing: 8) {
             Text("영업중")
-              .foregroundColor(.brown)
-              .font(.system(size: 14, weight: .bold))
+              .foregroundColor(CofficeAsset.Colors.secondary1.swiftUIColor)
+              .applyCofficeFont(font: .button)
               .frame(alignment: .leading)
             Text("목 09:00 ~ 21:00")
-              .foregroundColor(.gray)
-              .font(.system(size: 14))
+              .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
+              .applyCofficeFont(font: .body1Medium)
             Spacer()
           }
           .padding(.top, 16)
@@ -78,8 +77,7 @@ struct CafeSearchDetailHeaderView: View {
           Divider()
             .padding(.top, 20)
         }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 10)
+        .padding(EdgeInsets(top: 20, leading: 20, bottom: 16, trailing: 20))
       }
     }
   }

--- a/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailHeaderView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailHeaderView.swift
@@ -57,7 +57,11 @@ struct CafeSearchDetailHeaderView: View {
             }
 
             VStack {
-              CofficeAsset.Asset.bookmarkLine40px.swiftUIImage
+              Button {
+                // TODO: 북마크 API 연동 필요
+              } label: {
+                CofficeAsset.Asset.bookmarkLine40px.swiftUIImage
+              }
               Spacer()
             }
           }
@@ -74,8 +78,9 @@ struct CafeSearchDetailHeaderView: View {
           }
           .padding(.top, 16)
 
-          Divider()
-            .padding(.top, 20)
+          CofficeAsset.Colors.grayScale3.swiftUIColor
+            .frame(height: 1)
+            .padding(.top, 21)
         }
         .padding(EdgeInsets(top: 20, leading: 20, bottom: 16, trailing: 20))
       }

--- a/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailMenuView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailMenuView.swift
@@ -28,7 +28,7 @@ struct CafeSearchDetailMenuView: View {
           reviewMenuView
         }
       }
-      .padding(.top, 32)
+      .padding(.top, 16)
     }
   }
 }
@@ -60,6 +60,7 @@ extension CafeSearchDetailMenuView {
 
         Spacer()
       }
+      .frame(height: 52)
     }
   }
 }
@@ -246,8 +247,8 @@ extension CafeSearchDetailMenuView {
     WithViewStore(store) { viewStore in
       HStack {
         Text("리뷰 10")
-          .foregroundColor(.black)
-          .font(.system(size: 16, weight: .bold))
+          .foregroundColor(CofficeAsset.Colors.grayScale8.swiftUIColor)
+          .applyCofficeFont(font: .header3)
           .frame(height: 52)
 
         Spacer()
@@ -257,19 +258,18 @@ extension CafeSearchDetailMenuView {
         } label: {
           HStack(spacing: 5) {
             Text("리뷰 쓰기")
-              .foregroundColor(.brown)
-              .font(.system(size: 12))
+              .foregroundColor(CofficeAsset.Colors.secondary1.swiftUIColor)
+              .applyCofficeFont(font: .body2Medium)
               .padding(.vertical, 10)
-              .padding(.leading, 10)
-            Image(systemName: "pencil")
-              .resizable()
-              .frame(width: 10.5, height: 10.5)
+              .padding(.leading, 12)
+            CofficeAsset.Asset.pencilLine14px.swiftUIImage
+              .renderingMode(.template)
+              .foregroundColor(CofficeAsset.Colors.secondary1.swiftUIColor)
               .padding(.trailing, 10)
-              .tint(.brown)
           }
           .overlay(
             RoundedRectangle(cornerRadius: 4)
-              .stroke(.gray, lineWidth: 1)
+              .stroke(CofficeAsset.Colors.grayScale4.swiftUIColor, lineWidth: 1)
           )
         }
       }
@@ -279,7 +279,8 @@ extension CafeSearchDetailMenuView {
 
   private var userReviewListView: some View {
     WithViewStore(store) { _ in
-      VStack(spacing: 0) {
+      LazyVStack(spacing: 0) {
+        // TODO: 실제 리뷰 데이터 표출 필요
         ForEach(0..<10) { _ in
           userReviewCell
         }
@@ -293,20 +294,18 @@ extension CafeSearchDetailMenuView {
         VStack(spacing: 0) {
           HStack {
             VStack {
-              Image(systemName: "person.crop.circle")
-                .resizable()
-                .frame(width: 36, height: 36)
+              CofficeAsset.Asset.userProfile40px.swiftUIImage
               Spacer()
             }
 
             VStack(spacing: 4) {
               Text("수민")
-                .font(.system(size: 16, weight: .bold))
-                .foregroundColor(.black)
+                .foregroundColor(CofficeAsset.Colors.grayScale9.swiftUIColor)
+                .applyCofficeFont(font: .subtitleSemiBold)
                 .frame(maxWidth: .infinity, alignment: .leading)
               Text("5.24 토")
-                .font(.system(size: 12))
-                .foregroundColor(.gray)
+                .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
+                .applyCofficeFont(font: .body2Medium)
                 .frame(maxWidth: .infinity, alignment: .leading)
               Spacer()
             }
@@ -318,16 +317,11 @@ extension CafeSearchDetailMenuView {
                 // TODO: 수정/삭제 & 신고하기 이벤트 구현 필요
               } label: {
                 if Int.random(in: 0...1) == 0 {
-                  Image(systemName: "ellipsis")
-                    .resizable()
-                    .scaledToFit()
-                    .rotationEffect(.degrees(90))
-                    .frame(width: 18)
-                    .tint(.black)
+                  CofficeAsset.Asset.more2Fill24px.swiftUIImage
                 } else {
                   Text("수정/삭제")
-                    .foregroundColor(.gray)
-                    .font(.system(size: 12))
+                    .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
+                    .applyCofficeFont(font: .body2Medium)
                 }
               }
               Spacer()
@@ -343,35 +337,34 @@ extension CafeSearchDetailMenuView {
           오후엔 사람이 꽉차니 일찍오는 것 추천!
           """
         )
-        .foregroundColor(.gray)
-        .font(.system(size: 14))
+        .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
+        .applyCofficeFontWithoutLineSpacing(font: .body1)
         .multilineTextAlignment(.leading)
         .padding(.top, 20)
 
-        // TODO: Tag기 한줄 넘어갈 경우 표출 사양 확인 필요
+        // TODO: Tag기 한줄 넘어갈 경우 넘어가도록 커스텀 뷰 구현 필요
         HStack(spacing: 8) {
           ForEach(CafeSearchDetail.State.ReviewTagType.allCases, id: \.self) { tagType in
-            HStack(spacing: 4) {
-              Image(systemName: tagType.iconName)
-                .resizable()
-                .scaledToFit()
-                .frame(width: 12)
-                .padding(.leading, 8)
-              Text(tagType.title)
-                .foregroundColor(.gray)
-                .font(.system(size: 12))
-                .frame(height: 18)
-                .padding(.vertical, 4)
-                .padding(.trailing, 8)
-            }
-            .overlay(
-              RoundedRectangle(cornerRadius: 4).stroke(.gray, lineWidth: 1)
-            )
+            Text(tagType.title)
+              .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
+              .applyCofficeFont(font: .body2Medium)
+              .frame(height: 18)
+              .padding(.vertical, 4)
+              .padding(.horizontal, 8)
+              .overlay(
+                RoundedRectangle(cornerRadius: 4)
+                  .stroke(
+                    CofficeAsset.Colors.grayScale3.swiftUIColor,
+                    lineWidth: 1
+                  )
+              )
           }
         }
+        .frame(height: 26)
         .padding(.top, 20)
 
-        Divider()
+        CofficeAsset.Colors.grayScale3.swiftUIColor
+          .frame(height: 1)
           .padding(.top, 16)
       }
     }

--- a/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailMenuView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailMenuView.swift
@@ -45,14 +45,13 @@ extension CafeSearchDetailMenuView {
           } label: {
             VStack(spacing: 0) {
               Text(viewState.title)
-                .foregroundColor(viewState.isSelected ? .black : .gray)
-                .font(.system(size: 16, weight: .bold))
+                .foregroundColor(viewState.foregroundColorAsset.swiftUIColor)
+                .applyCofficeFont(font: .header3)
                 .frame(height: 52, alignment: .center)
-                .background(.white)
+                .background(CofficeAsset.Colors.grayScale1.swiftUIColor)
                 .padding(.horizontal, 20)
                 .overlay(alignment: .bottom) {
-                  Color.clear
-                    .background(viewState.isSelected ? .black : .white)
+                  viewState.bottomBorderColorAsset.swiftUIColor
                     .frame(height: 4)
                 }
             }
@@ -70,8 +69,8 @@ extension CafeSearchDetailMenuView {
 extension CafeSearchDetailMenuView {
   private var detailInfoHeaderView: some View {
     Text("상세정보")
-      .foregroundColor(.black)
-      .font(.system(size: 16, weight: .bold))
+      .foregroundColor(CofficeAsset.Colors.grayScale9.swiftUIColor)
+      .applyCofficeFont(font: .header3)
       .frame(alignment: .leading)
       .frame(height: 52)
   }
@@ -92,15 +91,13 @@ extension CafeSearchDetailMenuView {
   private var snsInfoView: some View {
     WithViewStore(store) { viewStore in
       HStack {
-        Image(systemName: "network")
-          .resizable()
-          .frame(width: 18, height: 18)
+        CofficeAsset.Asset.globalLine18px.swiftUIImage
         Button {
           // TODO: SNS Link Action 구현 필요
         } label: {
           Text(viewStore.cafe?.homepageUrl ?? "https://www.instagram.com/hoxton_seoul최대...")
-            .foregroundColor(.brown)
-            .font(.system(size: 14))
+            .foregroundColor(CofficeAsset.Colors.secondary1.swiftUIColor)
+            .applyCofficeFont(font: .body1Medium)
             .frame(alignment: .leading)
             .frame(height: 30)
         }
@@ -110,6 +107,7 @@ extension CafeSearchDetailMenuView {
 
   private var mapInfoView: some View {
     WithViewStore(store) { _ in
+      // TODO: 지도 뷰 추가 필요
       Color.black
         .frame(height: 126)
     }
@@ -119,22 +117,18 @@ extension CafeSearchDetailMenuView {
     WithViewStore(store) { viewStore in
       VStack(spacing: 0) {
         HStack {
-          Image(systemName: "mappin")
-            .frame(width: 18, height: 18)
+          CofficeAsset.Asset.mapPinLine18px.swiftUIImage
 
           Text(viewStore.cafe?.address?.address ?? "서울 서대문구 연희로 91 2층")
-            .foregroundColor(.gray)
-            .font(.system(size: 14))
+            .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
+            .applyCofficeFont(font: .body1Medium)
             .frame(alignment: .leading)
             .frame(height: 20)
 
           Button {
             // TODO: 좌측 텍스트 복사 이벤트
           } label: {
-            Image(systemName: "doc.on.doc")
-              .resizable()
-              .frame(width: 18, height: 18)
-              .tint(.black)
+            CofficeAsset.Asset.fileCopyLine18px.swiftUIImage
           }
 
           Spacer()
@@ -148,12 +142,10 @@ extension CafeSearchDetailMenuView {
   private var contactInfoView: some View {
     WithViewStore(store) { viewStore in
       HStack {
-        Image(systemName: "phone")
-          .resizable()
-          .frame(width: 18, height: 18)
+        CofficeAsset.Asset.phoneFill18px.swiftUIImage
         Text(viewStore.cafe?.phoneNumber ?? "02) 123-4567")
-          .foregroundColor(.brown)
-          .font(.system(size: 14))
+          .foregroundColor(CofficeAsset.Colors.secondary1.swiftUIColor)
+          .applyCofficeFont(font: .body1Medium)
           .frame(alignment: .leading)
           .frame(height: 20)
       }
@@ -167,13 +159,8 @@ extension CafeSearchDetailMenuView {
       VStack(spacing: 0) {
         HStack {
           VStack {
-            Image(systemName: "clock")
-              .resizable()
-              .frame(width: 18, height: 18)
-              .tint(.black)
-              .background(
-                Circle().strokeBorder(.black, lineWidth: 1)
-              )
+            CofficeAsset.Asset.timeLine18px.swiftUIImage
+              .padding(.top, 5)
             Spacer()
           }
 
@@ -181,37 +168,36 @@ extension CafeSearchDetailMenuView {
             Button {
               viewStore.send(.toggleToPresentTextForTest)
             } label: {
-              HStack {
+              HStack(alignment: .top) {
                 Text("월 09:00 - 21:00")
-                  .foregroundColor(.gray)
-                  .font(.system(size: 14))
+                  .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
+                  .applyCofficeFontWithoutLineSpacing(font: .body1Medium)
                   .frame(height: 20)
                   .frame(alignment: .leading)
-
-                Image(systemName: viewStore.needToPresentRunningTimeDetailInfo ? "chevron.up" : "chevron.down")
-                  .resizable()
-                  .scaledToFit()
-                  .frame(width: 9.5)
-                  .tint(.gray)
+                  .padding(.top, 4)
+                viewStore.runningTimeDetailInfoArrowImageAsset.swiftUIImage
+                  .padding(.top, 2)
               }
             }
 
-            // TODO: 실제 API 연동 시에 운영시간 정보 관련 뷰 모델 구성 예정
+            // TODO: 실제 API 연동 시에 운영시간 정보 관련 뷰 모델 구성 및 레이아웃 수정 예정
             if viewStore.needToPresentRunningTimeDetailInfo {
               Text(viewStore.runningTimeDetailInfo)
-                .foregroundColor(.gray)
-                .font(.system(size: 14))
+                .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
+                .applyCofficeFontWithoutLineSpacing(font: .body1Medium)
                 .lineSpacing(4)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .fixedSize(horizontal: false, vertical: true)
-                .padding(.top, 4)
+                .padding(.top, 2)
             }
 
-            HStack {
+            HStack(alignment: .top) {
               VStack(spacing: 0) {
                 Text("- 브레이크 타임 :")
-                  .foregroundColor(.gray)
-                  .font(.system(size: 14))
+                  .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
+                  .applyCofficeFontWithoutLineSpacing(font: .body1Medium)
+                  .frame(height: 20)
+                  .padding(.top, 1)
                 Spacer()
               }
 
@@ -222,41 +208,23 @@ extension CafeSearchDetailMenuView {
                   주말) 15:00 ~ 16:00
                   """
                 )
-                .foregroundColor(.gray)
-                .font(.system(size: 14))
+                .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
+                .applyCofficeFontWithoutLineSpacing(font: .body1Medium)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .fixedSize(horizontal: false, vertical: true)
+                .frame(height: 40)
                 Spacer()
               }
             }
             .padding(.top, 5)
 
-            HStack {
-              VStack {
-                Text("- 주문마감 :")
-                  .foregroundColor(.gray)
-                  .font(.system(size: 14))
-                Spacer()
-              }
-
-              VStack {
-                Text(
-                  """
-                  주중) 마감 1시간 전
-                  주말) 마감 30분 전
-                  """
-                )
-                .foregroundColor(.gray)
-                .font(.system(size: 14))
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .fixedSize(horizontal: false, vertical: true)
-                Spacer()
-              }
-            }
+            Text("- 주문마감 : 21:00")
+              .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
+              .applyCofficeFontWithoutLineSpacing(font: .body1Medium)
+              .frame(height: 20)
           }
         }
       }
-      .padding(.top, 10)
+      .padding(.top, 4)
     }
   }
 }

--- a/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailSubInfoView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailSubInfoView.swift
@@ -25,7 +25,7 @@ struct CafeSearchDetailSubInfoView: View {
         }
         .padding(.horizontal, 20)
 
-        Color(UIColor.lightGray)
+        CofficeAsset.Colors.grayScale3.swiftUIColor
           .frame(height: 4)
           .padding(.top, 20)
       }
@@ -38,11 +38,11 @@ extension CafeSearchDetailSubInfoView {
     WithViewStore(store, observe: \.subPrimaryInfoViewStates) { viewStore in
       VStack(alignment: .leading, spacing: 0) {
         Text("카페정보")
-          .foregroundColor(.black)
-          .font(.system(size: 16, weight: .bold))
+          .foregroundColor(CofficeAsset.Colors.grayScale9.swiftUIColor)
+          .applyCofficeFont(font: .header3)
           .frame(alignment: .leading)
           .frame(height: 20)
-          .padding(.top, 16)
+          .padding(.top, 15)
 
         HStack {
           ForEach(viewStore.state) { viewState in
@@ -62,12 +62,12 @@ extension CafeSearchDetailSubInfoView {
                 }
               HStack(spacing: 8) {
                 Text(viewState.title)
-                  .foregroundColor(.black)
-                  .font(.system(size: 14))
+                  .foregroundColor(CofficeAsset.Colors.grayScale8.swiftUIColor)
+                  .applyCofficeFont(font: .button)
                   .frame(height: 20)
                 Text(viewState.description)
-                  .foregroundColor(.gray)
-                  .font(.system(size: 14))
+                  .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
+                  .applyCofficeFont(font: .body1Medium)
                   .frame(height: 20)
               }
               .fixedSize(horizontal: true, vertical: true)
@@ -93,8 +93,8 @@ extension CafeSearchDetailSubInfoView {
           VStack(spacing: 0) {
             ForEach(viewStore.state) { viewState in
               Text(viewState.title)
-                .foregroundColor(.black)
-                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(CofficeAsset.Colors.grayScale9.swiftUIColor)
+                .applyCofficeFont(font: .button)
                 .frame(height: 20)
                 .frame(maxWidth: 50, alignment: .leading)
                 .padding(.bottom, 16)
@@ -105,8 +105,8 @@ extension CafeSearchDetailSubInfoView {
             ForEach(viewStore.state) { viewState in
               HStack {
                 Text(viewState.description)
-                  .foregroundColor(.gray)
-                  .font(.system(size: 14))
+                  .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
+                  .applyCofficeFont(font: .body1Medium)
                   .frame(alignment: .leading)
 
                 if viewState.type == .congestion {
@@ -117,8 +117,8 @@ extension CafeSearchDetailSubInfoView {
                   Spacer()
 
                   Text("6월 22일 16:00 기준")
-                    .foregroundColor(.gray)
-                    .font(.system(size: 12))
+                    .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
+                    .applyCofficeFont(font: .body2Medium)
                     .frame(alignment: .trailing)
                 }
               }

--- a/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailSubInfoView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailSubInfoView.swift
@@ -80,8 +80,9 @@ extension CafeSearchDetailSubInfoView {
           .padding(.top, 16)
         }
 
-        Divider()
-          .padding(.top, 20)
+        CofficeAsset.Colors.grayScale3.swiftUIColor
+          .frame(height: 1)
+          .padding(.top, 33)
       }
     }
   }

--- a/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailView.swift
@@ -38,22 +38,28 @@ struct CafeSearchDetailView: View {
       }
       .navigationBarHidden(true)
       .ignoresSafeArea(.all, edges: .top)
-      .overlay(alignment: .topLeading, content: {
-        Button {
-          viewStore.send(.popView)
-        } label: {
-          ZStack(alignment: .center) {
-            Color.clear
-              .frame(width: 40, height: 40)
-            Image(systemName: "chevron.left")
-              .resizable()
-              .scaledToFit()
-              .frame(height: 21)
-              .tint(.white)
+      .overlay(alignment: .top, content: {
+        HStack {
+          Button {
+            viewStore.send(.popView)
+          } label: {
+            CofficeAsset.Asset.arrowLeftSLine40px.swiftUIImage
+              .renderingMode(.template)
+              .foregroundColor(CofficeAsset.Colors.grayScale1.swiftUIColor)
           }
-          .padding(.top, 4)
-          .padding(.leading, 8)
+
+          Spacer()
+
+          Button {
+            // TODO: 공유하기 기능 추가 필요
+          } label: {
+            CofficeAsset.Asset.shareBoxFill40px.swiftUIImage
+              .renderingMode(.template)
+              .foregroundColor(CofficeAsset.Colors.grayScale1.swiftUIColor)
+          }
         }
+        .padding(.top, 4)
+        .padding(.horizontal, 8)
       })
       .onAppear {
         viewStore.send(.onAppear)

--- a/Projects/Coffice/Sources/Fonts.swift
+++ b/Projects/Coffice/Sources/Fonts.swift
@@ -227,7 +227,7 @@ struct FontModifier: ViewModifier {
   }
 }
 
-struct TextFieldFontModifier: ViewModifier {
+struct FontWithoutLineSpacingViewModifier: ViewModifier {
   var font: CofficeFont
 
   init(font: CofficeFont) {
@@ -245,7 +245,7 @@ extension View {
     modifier(FontModifier(font: font))
   }
 
-  func applyCofficeFontForTextField(font: CofficeFont) -> some View {
-    modifier(TextFieldFontModifier(font: font))
+  func applyCofficeFontWithoutLineSpacing(font: CofficeFont) -> some View {
+    modifier(FontWithoutLineSpacingViewModifier(font: font))
   }
 }


### PR DESCRIPTION
## ☕️ PR 요약
- 카페 상세화면 UI 디자인가이드 적용했습니다.
- TODO
  - 카페 상세화면 지도뷰 추가
  - 카페 상세화면 API 미연동 정보 추가 연동


## 📸 ScreenShot
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/4a06d04b-8340-446c-ab3a-da03834757e9" width="200">


##### ✅ PR check list(PR 요청시 확인후 삭제해주세요)

```
- commit message가 적절한지 확인해주세요.
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```



#### Linked Issue

close #119 
