### PR TITLE
Feature/#137 커스텀 탭바 구조 수정, 마이페이지 동작연결

### DIFF
--- a/Projects/Coffice/Project.swift
+++ b/Projects/Coffice/Project.swift
@@ -42,6 +42,7 @@ let project = Project.app(
     .external(name: "Kingfisher"),
     .external(name: "NMapsMap"),
     .project(target: "Network", path: .relativeToRoot("Projects/Network")),
+    .external(name: "PopupView"),
     .external(name: "TCACoordinators")
   ],
   settings: .settings(

--- a/Projects/Coffice/Sources/App/AppCoordinatorCore.swift
+++ b/Projects/Coffice/Sources/App/AppCoordinatorCore.swift
@@ -36,12 +36,6 @@ struct AppCoordinator: ReducerProtocol {
       case .useAppAsNonMember:
         return .none
 
-      case .routeAction(_, action: .main(
-        .myPage(.routeAction(_, action: .myPage(.presentLoginPage))))
-      ):
-        state.routes.presentCover(.login(.init(isOnboarding: false)))
-        return .none
-
       case .routeAction(_, action: .login(.routeAction(_, action: .main(.dismissLoginPage)))):
         state.routes.dismiss()
         return .none

--- a/Projects/Coffice/Sources/App/AppDelegate.swift
+++ b/Projects/Coffice/Sources/App/AppDelegate.swift
@@ -26,8 +26,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
   }
 
   private func checkIsFirstLaunch() {
-    if UserDefaults.standard.bool(forKey: "alreadyLaunched").isFalse {
-      KeychainManager.shared.deleteUserToken()
+    if UserDefaults.standard.bool(forKey: "alreadyLaunched").isFalse && CoreNetwork.shared.token == nil {
       Task {
         let loginClient = LoginClient()
         try await loginClient.login(loginType: .anonymous, accessToken: nil)

--- a/Projects/Coffice/Sources/App/CommonBottomSheet/BottomSheet.swift
+++ b/Projects/Coffice/Sources/App/CommonBottomSheet/BottomSheet.swift
@@ -55,7 +55,6 @@ struct BottomSheetView: View {
     .background(CofficeAsset.Colors.grayScale1.swiftUIColor)
     .cornerRadius(12, corners: [.topLeft, .topRight])
     .transition(.move(edge: .bottom))
-
   }
 }
 
@@ -79,7 +78,6 @@ extension BottomSheetView {
         .padding(.top, 12)
     }
     .padding(.vertical, 20)
-
   }
 
   private var footerView: some View {
@@ -88,7 +86,6 @@ extension BottomSheetView {
       confirmButton
     }
     .padding(.horizontal, 20)
-
   }
 
   private var cancelButton: some View {

--- a/Projects/Coffice/Sources/App/CommonBottomSheet/BottomSheet.swift
+++ b/Projects/Coffice/Sources/App/CommonBottomSheet/BottomSheet.swift
@@ -1,0 +1,141 @@
+//
+//  BottomSheet.swift
+//  coffice
+//
+//  Created by 천수현 on 2023/07/11.
+//  Copyright © 2023 kr.co.yapp. All rights reserved.
+//
+
+import ComposableArchitecture
+import Foundation
+import PopupView
+import SwiftUI
+
+struct BottomSheetContent: Equatable {
+  static func customize<PopupContent: View>(
+    _ view: Popup<PopupContent>.PopupParameters
+  ) -> Popup<PopupContent>.PopupParameters {
+    view
+      .type(.toast)
+      .position(.bottom)
+      .isOpaque(true)
+      .closeOnTapOutside(true)
+      .backgroundColor(CofficeAsset.Colors.grayScale10.swiftUIColor.opacity(0.4))
+  }
+  static let mock = BottomSheetContent(
+    title: "제목",
+    description: "내용",
+    confirmButtonTitle: "확인",
+    cancelButtonTitle: "취소"
+  )
+
+  static func == (lhs: BottomSheetContent, rhs: BottomSheetContent) -> Bool {
+    lhs.id == rhs.id
+  }
+
+  private let id = UUID()
+  let title: String
+  let description: String
+  let confirmButtonTitle: String
+  let cancelButtonTitle: String
+}
+
+struct BottomSheetView: View {
+  let store: StoreOf<BottomSheetReducer>
+  let bottomSheetContent: BottomSheetContent
+
+  var body: some View {
+    VStack(spacing: 12) {
+      informationView
+      footerView
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.bottom, UIApplication.keyWindow?.safeAreaInsets.bottom)
+    .padding(.top, 20)
+    .background(CofficeAsset.Colors.grayScale1.swiftUIColor)
+    .cornerRadius(12, corners: [.topLeft, .topRight])
+    .transition(.move(edge: .bottom))
+
+  }
+}
+
+extension BottomSheetView {
+  private var informationView: some View {
+    VStack(spacing: 0) {
+      CofficeAsset.Asset.errorWarningFill40px.swiftUIImage
+        .renderingMode(.template)
+        .foregroundColor(CofficeAsset.Colors.grayScale5.swiftUIColor)
+        .frame(width: 40, height: 40)
+
+      Text(bottomSheetContent.title)
+        .applyCofficeFont(font: .header2)
+        .foregroundColor(CofficeAsset.Colors.grayScale9.swiftUIColor)
+        .padding(.top, 20)
+
+      Text(bottomSheetContent.description)
+        .multilineTextAlignment(.center)
+        .applyCofficeFont(font: .subtitle1Medium)
+        .foregroundColor(CofficeAsset.Colors.grayScale6.swiftUIColor)
+        .padding(.top, 12)
+    }
+    .padding(.vertical, 20)
+
+  }
+
+  private var footerView: some View {
+    HStack(alignment: .center, spacing: 12) {
+      cancelButton
+      confirmButton
+    }
+    .padding(.horizontal, 20)
+
+  }
+
+  private var cancelButton: some View {
+    WithViewStore(store) { viewStore in
+      Button {
+        viewStore.send(.cancelButtonTapped)
+      } label: {
+        Text(bottomSheetContent.cancelButtonTitle)
+          .foregroundColor(CofficeAsset.Colors.grayScale9.swiftUIColor)
+          .applyCofficeFont(font: .button)
+          .frame(maxWidth: .infinity, alignment: .center)
+          .frame(height: 44)
+          .overlay {
+            RoundedRectangle(cornerRadius: 4)
+              .stroke(CofficeAsset.Colors.grayScale4.swiftUIColor, lineWidth: 1)
+          }
+      }
+    }
+  }
+
+  private var confirmButton: some View {
+    WithViewStore(store) { viewStore in
+      Button {
+        viewStore.send(.confirmButtonTapped)
+      } label: {
+        Text(bottomSheetContent.title)
+          .foregroundColor(CofficeAsset.Colors.grayScale1.swiftUIColor)
+          .applyCofficeFont(font: .button)
+          .frame(maxWidth: .infinity, alignment: .center)
+          .frame(height: 44)
+          .background(
+            CofficeAsset.Colors.grayScale9.swiftUIColor
+              .frame(height: 44)
+              .cornerRadius(4, corners: .allCorners)
+          )
+      }
+    }
+  }
+}
+
+struct BottomSheetView_Previews: PreviewProvider {
+  static var previews: some View {
+    BottomSheetView(
+      store: .init(initialState: .initialState, reducer: {
+        BottomSheetReducer()
+      }),
+      bottomSheetContent: .mock
+    )
+  }
+}

--- a/Projects/Coffice/Sources/App/CommonBottomSheet/BottomSheetCore.swift
+++ b/Projects/Coffice/Sources/App/CommonBottomSheet/BottomSheetCore.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2023 kr.co.yapp. All rights reserved.
 //
 
-import Foundation
-
 import ComposableArchitecture
 import SwiftUI
 

--- a/Projects/Coffice/Sources/App/CommonBottomSheet/BottomSheetCore.swift
+++ b/Projects/Coffice/Sources/App/CommonBottomSheet/BottomSheetCore.swift
@@ -1,0 +1,33 @@
+//
+//  BottomSheetCore.swift
+//  coffice
+//
+//  Created by 천수현 on 2023/07/11.
+//  Copyright © 2023 kr.co.yapp. All rights reserved.
+//
+
+import Foundation
+
+import ComposableArchitecture
+import SwiftUI
+
+struct BottomSheetReducer: ReducerProtocol {
+  struct State: Equatable {
+    static let initialState: Self = .init()
+
+  }
+
+  enum Action: Equatable {
+    case confirmButtonTapped
+    case cancelButtonTapped
+  }
+
+  var body: some ReducerProtocolOf<BottomSheetReducer> {
+    Reduce { state, action in
+      switch action {
+      default:
+        return .none
+      }
+    }
+  }
+}

--- a/Projects/Coffice/Sources/App/Main/MainCoordinatorCore.swift
+++ b/Projects/Coffice/Sources/App/Main/MainCoordinatorCore.swift
@@ -27,9 +27,6 @@ struct MainCoordinator: ReducerProtocol {
     var savedListState: SavedListCoordinator.State
     var myPageState: MyPageCoordinator.State
     var tabBarState: TabBar.State
-    var selectedTab: TabBar.State.TabBarItemType {
-      tabBarState.selectedTab
-    }
 
     var filterSheetState: CafeFilterBottomSheet.State?
     var commonBottomSheetState: CommonBottomSheet.State?
@@ -39,7 +36,8 @@ struct MainCoordinator: ReducerProtocol {
     var shouldShowTabBarView = true
   }
 
-  enum Action: Equatable {
+  enum Action: Equatable, BindableAction {
+    case binding(BindingAction<State>)
     case home(HomeCoordinator.Action)
     case search(SearchCoordinator.Action)
     case savedList(SavedListCoordinator.Action)
@@ -55,6 +53,7 @@ struct MainCoordinator: ReducerProtocol {
   }
 
   var body: some ReducerProtocolOf<MainCoordinator> {
+    BindingReducer()
     Scope(state: \State.homeState, action: /Action.home) {
       HomeCoordinator()
     }
@@ -71,7 +70,7 @@ struct MainCoordinator: ReducerProtocol {
       MyPageCoordinator()
     }
 
-    Scope(state: \.tabBarState, action: /Action.tabBar) {
+    Scope(state: \State.tabBarState, action: /Action.tabBar) {
       TabBar()
     }
 
@@ -108,7 +107,7 @@ struct MainCoordinator: ReducerProtocol {
       case .onAppear:
         return .none
 
-      case let .tabBar(.selectTab(itemType)):
+      case .tabBar(.selectTab(let itemType)):
         debugPrint("selectedTab : \(itemType)")
         return .none
 

--- a/Projects/Coffice/Sources/App/Main/MainCoordinatorCore.swift
+++ b/Projects/Coffice/Sources/App/Main/MainCoordinatorCore.swift
@@ -98,12 +98,6 @@ struct MainCoordinator: ReducerProtocol {
         state.commonBottomSheetState = nil
         return .none
 
-      case .myPage(
-        .routeAction(_, .myPage(action: .presentCommonBottomSheet(let commonBottomSheetState)))
-      ):
-        state.commonBottomSheetState = commonBottomSheetState
-        return .none
-
       case .onAppear:
         return .none
 
@@ -137,14 +131,6 @@ struct MainCoordinator: ReducerProtocol {
 
       case .dismissToastMessageView:
         state.toastMessageState = nil
-        return .none
-
-      case .myPage(.hideTabBar):
-        state.shouldShowTabBarView = false
-        return .none
-
-      case .myPage(.showTabBar):
-        state.shouldShowTabBarView = true
         return .none
 
       default:

--- a/Projects/Coffice/Sources/App/Main/MainCoordinatorCore.swift
+++ b/Projects/Coffice/Sources/App/Main/MainCoordinatorCore.swift
@@ -31,7 +31,6 @@ struct MainCoordinator: ReducerProtocol {
     var filterSheetState: CafeFilterBottomSheet.State?
     var commonBottomSheetState: CommonBottomSheet.State?
     var bubbleMessageState: BubbleMessage.State?
-    var toastMessageState: Toast.State?
 
     var shouldShowTabBarView = true
   }
@@ -46,7 +45,6 @@ struct MainCoordinator: ReducerProtocol {
     case filterBottomSheet(action: CafeFilterBottomSheet.Action)
     case commonBottomSheet(action: CommonBottomSheet.Action)
     case bubbleMessage(BubbleMessage.Action)
-    case toastMessage(Toast.Action)
     case dismissToastMessageView
     case dismissBubbleMessageView
     case onAppear
@@ -119,26 +117,10 @@ struct MainCoordinator: ReducerProtocol {
         state.bubbleMessageState = bubbleMessageState
         return .none
 
-      case .search(
-        .routeAction(_, .cafeMap(.showToast(let toastMessageState)))
-      ):
-        state.shouldShowTabBarView = false
-        state.toastMessageState = toastMessageState
-        return .run { send in
-          try await Task.sleep(nanoseconds: 2_000_000_000) // 2초
-          await send(.dismissToastMessageView)
-        }
-
       case .dismissBubbleMessageView:
         state.shouldShowTabBarView = true
         state.bubbleMessageState = nil
         return .none
-
-      case .dismissToastMessageView:
-        state.shouldShowTabBarView = true
-        state.toastMessageState = nil
-        return .none
-
       case .myPage(.routeAction(_, .editProfile(.hideTabBar))):
         state.shouldShowTabBarView = false
         return .none

--- a/Projects/Coffice/Sources/App/Main/MainCoordinatorCore.swift
+++ b/Projects/Coffice/Sources/App/Main/MainCoordinatorCore.swift
@@ -133,6 +133,14 @@ struct MainCoordinator: ReducerProtocol {
         state.toastMessageState = nil
         return .none
 
+      case .myPage(.routeAction(_, .editProfile(.hideTabBar))):
+        state.shouldShowTabBarView = false
+        return .none
+
+      case .myPage(.routeAction(_, .editProfile(.showTabBar))):
+        state.shouldShowTabBarView = true
+        return .none
+
       default:
         return .none
       }

--- a/Projects/Coffice/Sources/App/Main/MainCoordinatorCore.swift
+++ b/Projects/Coffice/Sources/App/Main/MainCoordinatorCore.swift
@@ -77,6 +77,7 @@ struct MainCoordinator: ReducerProtocol {
     Reduce { state, action in
       switch action {
       case .filterBottomSheet(.dismiss):
+        state.shouldShowTabBarView = true
         state.filterSheetState = nil
         return .none
 
@@ -108,17 +109,20 @@ struct MainCoordinator: ReducerProtocol {
       case .search(
         .routeAction(_, .cafeMap(.cafeFilterMenus(action: .presentFilterBottomSheetView(let filterSheetState))))
       ):
+        state.shouldShowTabBarView = false
         state.filterSheetState = filterSheetState
         return .none
 
       case .search(.routeAction(_, .cafeSearchDetail(.presentBubbleMessageView(let bubbleMessageState)))),
           .filterBottomSheet(.presentBubbleMessageView(let bubbleMessageState)):
+        state.shouldShowTabBarView = false
         state.bubbleMessageState = bubbleMessageState
         return .none
 
       case .search(
         .routeAction(_, .cafeMap(.showToast(let toastMessageState)))
       ):
+        state.shouldShowTabBarView = false
         state.toastMessageState = toastMessageState
         return .run { send in
           try await Task.sleep(nanoseconds: 2_000_000_000) // 2초
@@ -126,10 +130,12 @@ struct MainCoordinator: ReducerProtocol {
         }
 
       case .dismissBubbleMessageView:
+        state.shouldShowTabBarView = true
         state.bubbleMessageState = nil
         return .none
 
       case .dismissToastMessageView:
+        state.shouldShowTabBarView = true
         state.toastMessageState = nil
         return .none
 

--- a/Projects/Coffice/Sources/App/Main/MainCoordinatorView.swift
+++ b/Projects/Coffice/Sources/App/Main/MainCoordinatorView.swift
@@ -16,12 +16,46 @@ struct MainCoordinatorView: View {
   var body: some View {
     WithViewStore(store) { viewStore in
       ZStack {
-        NavigationView {
-          mainView
-        }
+        TabView(
+          selection: viewStore.binding(\MainCoordinator.State.tabBarState.$bindableSelectedTab)
+        ) {
+          NavigationView {
+            SearchCoordinatorView(
+              store: store.scope(
+                state: \.searchState,
+                action: MainCoordinator.Action.search
+              )
+            )
+          }
+          .tag(TabBar.State.TabBarItemType.search)
 
-        if viewStore.shouldShowTabBarView {
-          tabBarView
+          NavigationView {
+            SavedListCoordinatorView(
+              store: store.scope(
+                state: \.savedListState,
+                action: MainCoordinator.Action.savedList
+              )
+            )
+          }
+          .tag(TabBar.State.TabBarItemType.savedList)
+
+          NavigationView {
+            MyPageCoordinatorView(
+              store: store.scope(
+                state: \.myPageState,
+                action: MainCoordinator.Action.myPage
+              )
+            )
+          }
+          .tag(TabBar.State.TabBarItemType.myPage)
+        }
+        .overlay(alignment: .bottom) {
+          TabBarView(
+            store: store.scope(
+              state: \.tabBarState,
+              action: MainCoordinator.Action.tabBar
+            )
+          )
         }
 
         IfLetStore(
@@ -61,50 +95,6 @@ struct MainCoordinatorView: View {
       }
       .onAppear {
         viewStore.send(.onAppear)
-      }
-    }
-  }
-
-  var mainView: some View {
-    WithViewStore(store, observe: \.selectedTab) { viewStore in
-      Group {
-        switch viewStore.state {
-        case .search:
-          SearchCoordinatorView(
-            store: store.scope(
-              state: \.searchState,
-              action: MainCoordinator.Action.search
-            )
-          )
-        case .savedList:
-          SavedListCoordinatorView(
-            store: store.scope(
-              state: \.savedListState,
-              action: MainCoordinator.Action.savedList
-            )
-          )
-        case .myPage:
-          MyPageCoordinatorView(
-            store: store.scope(
-              state: \.myPageState,
-              action: MainCoordinator.Action.myPage
-            )
-          )
-        }
-      }
-    }
-  }
-
-  var tabBarView: some View {
-    WithViewStore(store) { viewStore in
-      VStack {
-        Spacer()
-        TabBarView(
-          store: store.scope(
-            state: \.tabBarState,
-            action: MainCoordinator.Action.tabBar
-          )
-        )
       }
     }
   }

--- a/Projects/Coffice/Sources/App/Main/MainCoordinatorView.swift
+++ b/Projects/Coffice/Sources/App/Main/MainCoordinatorView.swift
@@ -50,53 +50,61 @@ struct MainCoordinatorView: View {
           .tag(TabBar.State.TabBarItemType.myPage)
         }
         .overlay(alignment: .bottom) {
-          TabBarView(
-            store: store.scope(
-              state: \.tabBarState,
-              action: MainCoordinator.Action.tabBar
+          if viewStore.shouldShowTabBarView {
+            TabBarView(
+              store: store.scope(
+                state: \.tabBarState,
+                action: MainCoordinator.Action.tabBar
+              )
             )
+          } else {
+            tabBarTouchBlockerView
+          }
+
+          IfLetStore(
+            store.scope(
+              state: \.filterSheetState,
+              action: MainCoordinator.Action.filterBottomSheet
+            ),
+            then: CafeFilterBottomSheetView.init
           )
+
+          IfLetStore(
+            store.scope(
+              state: \.commonBottomSheetState,
+              action: MainCoordinator.Action.commonBottomSheet
+            ),
+            then: CommonBottomSheetView.init
+          )
+
+          IfLetStore(
+            store.scope(
+              state: \.toastMessageState,
+              action: MainCoordinator.Action.toastMessage
+            ),
+            then: ToastView.init
+          )
+
+          IfLetStore(
+            store.scope(
+              state: \.bubbleMessageState,
+              action: MainCoordinator.Action.bubbleMessage
+            ),
+            then: BubbleMessageView.init
+          )
+          .onTapGesture {
+            viewStore.send(.dismissBubbleMessageView)
+          }
         }
-
-        IfLetStore(
-          store.scope(
-            state: \.filterSheetState,
-            action: MainCoordinator.Action.filterBottomSheet
-          ),
-          then: CafeFilterBottomSheetView.init
-        )
-
-        IfLetStore(
-          store.scope(
-            state: \.commonBottomSheetState,
-            action: MainCoordinator.Action.commonBottomSheet
-          ),
-          then: CommonBottomSheetView.init
-        )
-
-        IfLetStore(
-          store.scope(
-            state: \.toastMessageState,
-            action: MainCoordinator.Action.toastMessage
-          ),
-          then: ToastView.init
-        )
-
-        IfLetStore(
-          store.scope(
-            state: \.bubbleMessageState,
-            action: MainCoordinator.Action.bubbleMessage
-          ),
-          then: BubbleMessageView.init
-        )
-        .onTapGesture {
-          viewStore.send(.dismissBubbleMessageView)
+        .onAppear {
+          viewStore.send(.onAppear)
         }
-      }
-      .onAppear {
-        viewStore.send(.onAppear)
       }
     }
+  }
+  private var tabBarTouchBlockerView: some View {
+    Color.white.opacity(0.0001)
+      .frame(height: 65)
   }
 }
 

--- a/Projects/Coffice/Sources/App/Main/MainCoordinatorView.swift
+++ b/Projects/Coffice/Sources/App/Main/MainCoordinatorView.swift
@@ -79,14 +79,6 @@ struct MainCoordinatorView: View {
 
           IfLetStore(
             store.scope(
-              state: \.toastMessageState,
-              action: MainCoordinator.Action.toastMessage
-            ),
-            then: ToastView.init
-          )
-
-          IfLetStore(
-            store.scope(
               state: \.bubbleMessageState,
               action: MainCoordinator.Action.bubbleMessage
             ),

--- a/Projects/Coffice/Sources/App/Main/MyPage/Coordinator+Screen/MyPageCoordinatorCore.swift
+++ b/Projects/Coffice/Sources/App/Main/MyPage/Coordinator+Screen/MyPageCoordinatorCore.swift
@@ -21,27 +21,26 @@ struct MyPageCoordinator: ReducerProtocol {
   enum Action: IndexedRouterAction, Equatable {
     case routeAction(Int, action: MyPageScreen.Action)
     case updateRoutes([Route<MyPageScreen.State>])
-    case hideTabBar
-    case showTabBar
   }
 
   var body: some ReducerProtocolOf<MyPageCoordinator> {
     Reduce<State, Action> { state, action in
       switch action {
-      case .routeAction(_, action: .myPage(.pushToLocationServiceTermsView)):
-        state.routes.push(.locationServiceTerms(.initialState))
+      case .routeAction(_, action: .myPage(.menuButtonTapped(let menuItem))):
+        switch menuItem.menuType {
+        case .privacyPolicy:
+          state.routes.push(.privacyPolicy(.initialState))
+        case .locationServiceTerms:
+          state.routes.push(.locationServiceTerms(.initialState))
+        case .contact:
+          state.routes.push(.contact(.initialState))
+        default:
+          break
+        }
         return .none
 
-      case .routeAction(_, action: .myPage(.pushToPrivacyPolicy)):
-        state.routes.push(.privacyPolicy(.initialState))
-        return .none
-
-      case .routeAction(_, action: .myPage(.pushToContactView)):
-        state.routes.push(.contact(.initialState))
-        return .none
-
-      case .routeAction(_, action: .myPage(.pushToEditProfile)):
-        state.routes.push(.editProfile(.initialState))
+      case .routeAction(_, action: .myPage(.editProfileButtonTapped(let nickname))):
+        state.routes.push(.editProfile(.init(nickname: nickname)))
         return .none
 
       case .routeAction(_, action: .locationServiceTerms(.popView)),
@@ -50,12 +49,6 @@ struct MyPageCoordinator: ReducerProtocol {
           .routeAction(_, action: .editProfile(.popView)):
         state.routes.pop()
         return .none
-
-      case .routeAction(_, action: .editProfile(.hideTabBar)):
-        return EffectTask(value: .hideTabBar)
-
-      case .routeAction(_, action: .editProfile(.showTabBar)):
-        return EffectTask(value: .showTabBar)
 
       default:
         return .none

--- a/Projects/Coffice/Sources/App/Main/MyPage/EditProfile/EditProfileCore.swift
+++ b/Projects/Coffice/Sources/App/Main/MyPage/EditProfile/EditProfileCore.swift
@@ -11,11 +11,15 @@ import SwiftUI
 
 struct EditProfile: ReducerProtocol {
   struct State: Equatable {
-    static let initialState: State = .init()
+    static let initialState: State = .init(nickname: "기존닉네임")
 
     let title = "프로필 수정"
-    @BindingState var nicknameTextField = "기존닉네임"
+    @BindingState var nicknameTextField: String
     var isNicknameValid = false
+
+    init(nickname: String) {
+      nicknameTextField = nickname
+    }
   }
 
   enum Action: Equatable, BindableAction {

--- a/Projects/Coffice/Sources/App/Main/MyPage/EditProfile/EditProfileCore.swift
+++ b/Projects/Coffice/Sources/App/Main/MyPage/EditProfile/EditProfileCore.swift
@@ -13,12 +13,16 @@ struct EditProfile: ReducerProtocol {
   struct State: Equatable {
     static let initialState: State = .init(nickname: "기존닉네임")
 
+    let oldNickname: String
     let title = "프로필 수정"
     @BindingState var nicknameTextField: String
-    var isNicknameValid = false
+    var isNicknameValid: Bool {
+      return oldNickname != nicknameTextField && nicknameTextField.isNotEmpty
+    }
 
     init(nickname: String) {
-      nicknameTextField = nickname
+      oldNickname = nickname
+      nicknameTextField = oldNickname
     }
   }
 
@@ -50,7 +54,7 @@ struct EditProfile: ReducerProtocol {
         return .none
 
       case .confirmButtonTapped:
-        return .none
+        return EffectTask(value: .popView) // TODO: 서버 나오면 기능 연결 (닉네임 수정 확인)
 
       case .clearText:
         state.nicknameTextField.removeAll()

--- a/Projects/Coffice/Sources/App/Main/MyPage/EditProfile/EditProfileView.swift
+++ b/Projects/Coffice/Sources/App/Main/MyPage/EditProfile/EditProfileView.swift
@@ -115,7 +115,7 @@ struct EditProfileView_Previews: PreviewProvider {
   static var previews: some View {
     EditProfileView(
       store: .init(
-        initialState: .init(),
+        initialState: .initialState,
         reducer: EditProfile()
       )
     )

--- a/Projects/Coffice/Sources/App/Main/MyPage/EditProfile/EditProfileView.swift
+++ b/Projects/Coffice/Sources/App/Main/MyPage/EditProfile/EditProfileView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 struct EditProfileView: View {
   private let store: StoreOf<EditProfile>
+  @FocusState private var isFocused: Bool?
 
   init(store: StoreOf<EditProfile>) {
     self.store = store
@@ -64,6 +65,7 @@ struct EditProfileView: View {
             .textFieldStyle(.plain)
             .padding(20)
             .tint(CofficeAsset.Colors.grayScale9.swiftUIColor)
+            .focused($isFocused, equals: true)
 
             if viewStore.nicknameTextField.isNotEmpty {
               Button {

--- a/Projects/Coffice/Sources/App/Main/MyPage/MyPageCore.swift
+++ b/Projects/Coffice/Sources/App/Main/MyPage/MyPageCore.swift
@@ -11,6 +11,127 @@ import Foundation
 import SwiftUI
 
 struct MyPage: ReducerProtocol {
+  struct State: Equatable {
+    var user: User?
+    var menuItems: [MenuItem] = MenuType.allCases.map(MenuItem.init)
+    var versionNumber: String {
+      let versionNumber = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+      return versionNumber ?? "1.0.0"
+    }
+    var bottomSheetState: BottomSheetReducer.State = .initialState
+    @BindingState var shouldShowBottomSheet = false
+    var bottomSheetType: BottomSheetType = .logout
+  }
+
+  enum Action: Equatable, BindableAction {
+    case binding(BindingAction<State>)
+    case bottomSheet(BottomSheetReducer.Action)
+    case onAppear
+    case menuButtonTapped(MenuItem)
+    case editProfileButtonTapped(nickname: String)
+    case userInfoFetched(User)
+    case logoutButtonTapped
+    case memberLeaveButtonTapped
+    case logout
+    case memberLeave
+  }
+
+  @Dependency(\.loginClient) private var loginClient
+
+  var body: some ReducerProtocolOf<MyPage> {
+    BindingReducer()
+    Reduce { state, action in
+      switch action {
+      case .binding:
+        return .none
+
+      case .onAppear:
+        return .run { send in
+          let userData = try await loginClient.fetchUserData()
+          await send(.userInfoFetched(userData))
+        } catch: { error, send in
+          debugPrint(error)
+        }
+
+      case .userInfoFetched(let user):
+        state.user = user
+        return .none
+
+      case .bottomSheet(.confirmButtonTapped):
+        return .run { [bottomSheetType = state.bottomSheetType] send in
+          switch bottomSheetType {
+          case .logout:
+            await send(.logout)
+          case .memberLeave:
+            await send(.memberLeave)
+          }
+        }
+
+      case .menuButtonTapped(let menuItem):
+        return .run { send in
+          switch menuItem.menuType {
+          case .logout:
+            await send(.logoutButtonTapped)
+
+          case .memberLeave:
+            await send(.memberLeaveButtonTapped)
+
+          default:
+            break
+          }
+        }
+
+      case .logout:
+        return .none
+
+      case .memberLeave:
+        return .none
+
+      case .bottomSheet(.cancelButtonTapped):
+        state.shouldShowBottomSheet = false
+        return .none
+
+      case .logoutButtonTapped:
+        state.bottomSheetType = .logout
+        state.shouldShowBottomSheet = true
+        return .none
+
+      case .memberLeaveButtonTapped:
+        state.bottomSheetType = .memberLeave
+        state.shouldShowBottomSheet = true
+        return .none
+
+      default:
+        return .none
+      }
+    }
+  }
+}
+
+extension MyPage {
+  enum BottomSheetType {
+    case logout
+    case memberLeave
+
+    var content: BottomSheetContent {
+      switch self {
+      case .logout:
+        return .init(
+          title: "로그아웃",
+          description: "내용",
+          confirmButtonTitle: "확인",
+          cancelButtonTitle: "취소"
+        )
+      case .memberLeave:
+        return .init(
+          title: "회원탈퇴",
+          description: "내용",
+          confirmButtonTitle: "확인",
+          cancelButtonTitle: "취소"
+        )
+      }
+    }
+  }
   struct MenuItem: Equatable, Identifiable {
     let id = UUID()
     let menuType: MenuType
@@ -49,102 +170,5 @@ struct MyPage: ReducerProtocol {
     case versionInformation
     case logout
     case memberLeave
-  }
-
-  struct State: Equatable {
-    var user: User?
-    var menuItems: [MenuItem] = MenuType.allCases.map(MenuItem.init)
-    var versionNumber: String {
-      let versionNumber = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
-      return versionNumber ?? "1.0.0"
-    }
-
-    init() {
-      menuItems = MenuType.allCases.map(MenuItem.init)
-    }
-  }
-
-  enum Action: Equatable {
-    case onAppear
-    case menuButtonTapped(MenuItem)
-    case editProfileButtonTapped
-    case userInfoFetched(User)
-    case pushToLocationServiceTermsView
-    case pushToPrivacyPolicy
-    case pushToContactView
-    case pushToEditProfile
-    case presentLoginPage
-    case showCommonBottomSheet(
-      title: String,
-      description: String,
-      cancelButtonTitle: String,
-      confirmButtonTitle: String
-    )
-    case presentCommonBottomSheet(CommonBottomSheet.State)
-  }
-
-  @Dependency(\.loginClient) private var loginClient
-
-  var body: some ReducerProtocolOf<MyPage> {
-    Reduce { state, action in
-      switch action {
-      case .onAppear:
-        return .run { send in
-          let userData = try await loginClient.fetchUserData()
-          await send(.userInfoFetched(userData))
-        } catch: { error, send in
-          debugPrint(error)
-        }
-
-      case .userInfoFetched(let user):
-        state.user = user
-        return .none
-
-      case .editProfileButtonTapped:
-        return EffectTask(value: .pushToEditProfile)
-
-      case .menuButtonTapped(let menuItem):
-        switch menuItem.menuType {
-        case .privacyPolicy:
-          return EffectTask(value: .pushToPrivacyPolicy)
-
-        case .locationServiceTerms:
-          return EffectTask(value: .pushToLocationServiceTermsView)
-
-        case .contact:
-          return EffectTask(value: .pushToContactView)
-
-        case .versionInformation:
-          return .none
-
-        case .logout:
-          return EffectTask(
-            value: .presentCommonBottomSheet(
-              .init(
-                title: "로그아웃",
-                description: "정말 로그아웃 하시겠어요?",
-                cancelButtonTitle: "나가기",
-                confirmButtonTitle: "로그아웃"
-              )
-            )
-          )
-
-        case .memberLeave:
-          return EffectTask(
-            value: .presentCommonBottomSheet(
-              .init(
-                title: "회원탈퇴",
-                description: "삭제된 데이터는 복구가 불가능합니다.\n등록된 리뷰, 게시물은 탈퇴 후에도 유지되니\n삭제 후 탈퇴하시길 바랍니다. ",
-                cancelButtonTitle: "닫기",
-                confirmButtonTitle: "탈퇴하기"
-              )
-            )
-          )
-        }
-
-      default:
-        return .none
-      }
-    }
   }
 }

--- a/Projects/Coffice/Sources/App/Main/MyPage/MyPageCore.swift
+++ b/Projects/Coffice/Sources/App/Main/MyPage/MyPageCore.swift
@@ -42,9 +42,6 @@ struct MyPage: ReducerProtocol {
     BindingReducer()
     Reduce { state, action in
       switch action {
-      case .binding:
-        return .none
-
       case .onAppear:
         return .run { send in
           let userData = try await loginClient.fetchUserData()
@@ -57,16 +54,14 @@ struct MyPage: ReducerProtocol {
         state.user = user
         return .none
 
-      case .bottomSheet(.confirmButtonTapped):
-        return .run { [bottomSheetType = state.bottomSheetType] send in
-          switch bottomSheetType {
-          case .logout:
-            await send(.logout)
-          case .memberLeave:
-            await send(.memberLeave)
-          }
-        }
+        // MARK: MyPage Actions
+      case .logout:
+        return .none // TODO: 서버 나오면 기능 연결 (로그아웃)
 
+      case .memberLeave:
+        return .none // TODO: 서버 나오면 기능 연결 (회원탈퇴)
+
+        // MARK: MyPageButton Tap Events
       case .menuButtonTapped(let menuItem):
         return .run { send in
           switch menuItem.menuType {
@@ -81,16 +76,6 @@ struct MyPage: ReducerProtocol {
           }
         }
 
-      case .logout:
-        return .none
-
-      case .memberLeave:
-        return .none
-
-      case .bottomSheet(.cancelButtonTapped):
-        state.shouldShowBottomSheet = false
-        return .none
-
       case .logoutButtonTapped:
         state.bottomSheetType = .logout
         state.shouldShowBottomSheet = true
@@ -99,6 +84,21 @@ struct MyPage: ReducerProtocol {
       case .memberLeaveButtonTapped:
         state.bottomSheetType = .memberLeave
         state.shouldShowBottomSheet = true
+        return .none
+
+        // MARK: BottomSheetButton Tap Events
+      case .bottomSheet(.confirmButtonTapped):
+        return .run { [bottomSheetType = state.bottomSheetType] send in
+          switch bottomSheetType {
+          case .logout:
+            await send(.logout)
+          case .memberLeave:
+            await send(.memberLeave)
+          }
+        }
+
+      case .bottomSheet(.cancelButtonTapped):
+        state.shouldShowBottomSheet = false
         return .none
 
       default:
@@ -118,16 +118,16 @@ extension MyPage {
       case .logout:
         return .init(
           title: "로그아웃",
-          description: "내용",
-          confirmButtonTitle: "확인",
-          cancelButtonTitle: "취소"
+          description: "정말 로그아웃 하시겠어요?",
+          confirmButtonTitle: "로그아웃",
+          cancelButtonTitle: "닫기"
         )
       case .memberLeave:
         return .init(
           title: "회원탈퇴",
-          description: "내용",
-          confirmButtonTitle: "확인",
-          cancelButtonTitle: "취소"
+          description: "삭제된 데이터는 복구가 불가능합니다.\n등록된 리뷰, 게시물은 탈퇴 후에도 유지되니\n삭제 후 탈퇴하시길 바랍니다.",
+          confirmButtonTitle: "탈퇴하기",
+          cancelButtonTitle: "닫기"
         )
       }
     }

--- a/Projects/Coffice/Sources/App/Main/MyPage/MyPageView.swift
+++ b/Projects/Coffice/Sources/App/Main/MyPage/MyPageView.swift
@@ -7,6 +7,7 @@
 //
 
 import ComposableArchitecture
+import PopupView
 import SwiftUI
 
 struct MyPageView: View {
@@ -22,6 +23,19 @@ struct MyPageView: View {
         .onAppear {
           viewStore.send(.onAppear)
         }
+        .popup(
+          isPresented: viewStore.$shouldShowBottomSheet,
+          view: {
+            BottomSheetView(
+              store: store.scope(
+                state: \.bottomSheetState,
+                action: MyPage.Action.bottomSheet
+              ),
+              bottomSheetContent: viewStore.bottomSheetType.content
+            )
+          },
+          customize: { BottomSheetContent.customize($0) }
+        )
     }
   }
 
@@ -61,7 +75,7 @@ struct MyPageView: View {
           .foregroundColor(CofficeAsset.Colors.grayScale9.swiftUIColor)
         Spacer()
         Button {
-          viewStore.send(.editProfileButtonTapped)
+          viewStore.send(.editProfileButtonTapped(nickname: viewStore.user?.name ?? "기존닉네임"))
         } label: {
           HStack(spacing: 0) {
             Text("SNS 로그인")
@@ -131,6 +145,7 @@ struct MyPageView: View {
             }
             .tint(menuItem.textColor)
           }
+          .disabled(menuItem.menuType == .versionInformation)
         }
       }
     }

--- a/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
+++ b/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
@@ -101,7 +101,6 @@ struct SavedListView: View {
           }
           .padding(.horizontal, 20)
         }
-        .padding(.bottom, TabBarSizePreferenceKey.defaultValue.height)
       }
     }
   }

--- a/Projects/Coffice/Sources/App/Main/Search/CafeMapView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeMapView.swift
@@ -17,7 +17,6 @@ struct CafeMapView: View {
       GeometryReader { geometry in
         ZStack {
           NaverMapView(viewStore: viewStore)
-            .ignoresSafeArea()
           switch viewStore.displayViewType {
           case .searchResultView:
             CafeSearchListView(store: store.scope(

--- a/Projects/Coffice/Sources/App/Main/Search/CafeMapView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeMapView.swift
@@ -55,7 +55,6 @@ struct CafeMapView: View {
             if viewStore.selectedCafe != nil {
               CafeCardView(store: store)
                 .frame(width: geometry.size.width)
-                .padding(.bottom, TabBarSizePreferenceKey.defaultValue.height)
             }
           }
           .frame(

--- a/Projects/Coffice/Sources/App/Main/Search/CafeMapView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeMapView.swift
@@ -9,6 +9,7 @@
 import ComposableArchitecture
 import NMapsMap
 import SwiftUI
+import PopupView
 
 struct CafeMapView: View {
   let store: StoreOf<CafeMapCore>
@@ -76,6 +77,17 @@ struct CafeMapView: View {
       }
       .onDisappear {
         viewStore.send(.onDisappear)
+      }
+      .popup(isPresented: viewStore.$shouldShowToast) {
+        ToastView(
+          title: "장소가 저장되었습니다.",
+          image: CofficeAsset.Asset.checkboxCircleFill18px,
+          config: ToastConfiguration.default
+        )
+      } customize: {
+        $0
+          .type(.floater(verticalPadding: 16, horizontalPadding: 0, useSafeAreaInset: false))
+          .autohideIn(2)
       }
     }
   }

--- a/Projects/Coffice/Sources/App/Main/ToastConfiguration.swift
+++ b/Projects/Coffice/Sources/App/Main/ToastConfiguration.swift
@@ -10,39 +10,8 @@ import ComposableArchitecture
 import Foundation
 import SwiftUI
 
-struct Toast: ReducerProtocol {
-  struct State: Equatable {
-    let title: String
-    let image: CofficeImages
-    let config: Config
-  }
-
-  enum Action: Equatable {
-    case onAppear
-  }
-
-  var body: some ReducerProtocolOf<Toast> {
-    Reduce { state, action in
-      switch action {
-      case .onAppear:
-        return .none
-      }
-    }
-  }
-}
-
-extension Toast.State {
-  static var mock: Self {
-    .init(
-      title: "장소가 저장되었습니다.",
-      image: CofficeAsset.Asset.checkboxCircleFill18px,
-      config: Config.default
-    )
-  }
-}
-
-struct Config: Equatable {
-  static let `default` = Config()
+struct ToastConfiguration: Equatable {
+  static let `default` = ToastConfiguration()
   let textColor: Color
   let font: CofficeFont
   let backgroundColor: Color

--- a/Projects/Coffice/Sources/App/Main/ToastView.swift
+++ b/Projects/Coffice/Sources/App/Main/ToastView.swift
@@ -6,46 +6,40 @@
 //  Copyright © 2023 kr.co.yapp. All rights reserved.
 //
 
-import ComposableArchitecture
 import SwiftUI
 
 struct ToastView: View {
-  private let store: StoreOf<Toast>
-
-  init(store: StoreOf<Toast>) {
-    self.store = store
-  }
+  let title: String
+  let image: CofficeImages
+  let config: ToastConfiguration
 
   var body: some View {
-    WithViewStore(store) { viewStore in
-      VStack {
-        Spacer()
-        HStack {
-          viewStore.state.image.swiftUIImage
-            .renderingMode(.template)
-            .foregroundColor(CofficeAsset.Colors.grayScale1.swiftUIColor)
-          Text(viewStore.state.title)
-            .multilineTextAlignment(.center)
-            .foregroundColor(viewStore.state.config.textColor)
-            .applyCofficeFont(font: viewStore.state.config.font)
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 13)
-        .background(viewStore.state.config.backgroundColor)
-        .cornerRadius(8)
+    VStack {
+      Spacer()
+      HStack {
+        image.swiftUIImage
+          .renderingMode(.template)
+          .foregroundColor(CofficeAsset.Colors.grayScale1.swiftUIColor)
+        Text(title)
+          .multilineTextAlignment(.center)
+          .foregroundColor(config.textColor)
+          .applyCofficeFont(font: config.font)
       }
-      .padding(.bottom, 100)
+      .padding(.horizontal, 16)
+      .padding(.vertical, 13)
+      .background(config.backgroundColor)
+      .cornerRadius(8)
     }
+    .padding(.bottom, 100)
   }
 }
 
 struct ToastView_Previews: PreviewProvider {
   static var previews: some View {
     ToastView(
-      store: .init(
-        initialState: .mock,
-        reducer: Toast()
-      )
+      title: "장소가 저장되었습니다.",
+      image: CofficeAsset.Asset.checkboxCircleFill18px,
+      config: ToastConfiguration.default
     )
   }
 }

--- a/Projects/Coffice/Sources/App/TabBar/TabBarCore.swift
+++ b/Projects/Coffice/Sources/App/TabBar/TabBarCore.swift
@@ -21,25 +21,27 @@ struct TabBar: ReducerProtocol {
       .init(type: .myPage, isSelected: false)
     ]
 
-    var selectedTab: TabBarItemType = .search {
+    @BindingState var bindableSelectedTab: TabBarItemType = .search {
       didSet {
         tabBarItemViewStates = tabBarItemTypes.map {
-          TabBarItemViewState(type: $0, isSelected: selectedTab == $0)
+          TabBarItemViewState(type: $0, isSelected: bindableSelectedTab == $0)
         }
       }
     }
   }
 
-  enum Action: Equatable {
+  enum Action: Equatable, BindableAction {
+    case binding(BindingAction<State>)
     case selectTab(TabBar.State.TabBarItemType)
     case tabBarView(isPresented: Bool)
   }
 
   var body: some ReducerProtocolOf<TabBar> {
+    BindingReducer()
     Reduce { state, action in
       switch action {
       case .selectTab(let itemType):
-        state.selectedTab = itemType
+        state.bindableSelectedTab = itemType
         return .none
 
       default:
@@ -50,7 +52,7 @@ struct TabBar: ReducerProtocol {
 }
 
 extension TabBar.State {
-  enum TabBarItemType: CaseIterable {
+  enum TabBarItemType: CaseIterable, Hashable {
     case search
     case savedList
     case myPage

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -15,7 +15,8 @@ let dependencies = Dependencies(
     .remote(url: "https://github.com/jaemyeong/NMapsMap-SPM.git", requirement: .upToNextMajor(from: "3.16.2")),
     .remote(url: "https://github.com/firebase/firebase-ios-sdk.git", requirement: .upToNextMajor(from: "10.10.0")),
     .remote(url: "https://github.com/kakao/kakao-ios-sdk", requirement: .branch("master")),
-    .remote(url: "https://github.com/onevcat/Kingfisher.git", requirement: .upToNextMajor(from: "7.0.0"))
+    .remote(url: "https://github.com/onevcat/Kingfisher.git", requirement: .upToNextMajor(from: "7.0.0")),
+    .remote(url: "https://github.com/exyte/PopupView.git", requirement: .upToNextMajor(from: "2.5.0"))
   ],
   platforms: [.iOS]
 )


### PR DESCRIPTION
## ☕️ PR 요약
- custom tab bar 구조를 변경했습니다. (TabView로 변경)
- 공용으로 사용할 BottomSheet를 제작하였습니다.
  - PopupView 라이브러리를 활용했습니다.
  - 사용방법은 myPage 코드를 참고해주세요.
- 마이페이지 화면전환쪽 불필요한 코드를 삭제하거나 묶음으로써 리팩토링했습니다.

### 참고사항

#### tabBarTouchBlockerView가 생긴 이유
```swift
  private var tabBarTouchBlockerView: some View {
    Color.white.opacity(0.0001)
      .frame(height: 65)
  }
```
현재 저희 팀이 사용하는 탭바는 시스템이 기본적으로 만들어주는 탭바 위에
커스텀 탭바를 overlay하는 형식입니다.
shouldShowTabBarView를 통해 커스텀 탭바를 hidden 시키게 되면
그 아래에 있던 시스템 기본 탭바가 노출되어 (보이진 않지만 투명 버튼이 존재)
탭바를 숨기게 되더라도 하단을 탭하면 다른 탭으로 이동하는 버그가 있습니다.

이를 막기 위해 탭바사이즈와 같은 영역을 차지하는 View를 얹어주었습니다.
**이때 clear 색상을 쓰면 탭 이벤트가 아래까지 전달되기에 위와 같은 코드를 작성했습니다.**
**white color를 쓰면 화면전환시 white 영역이 차지하는 공간이 네비게이션 push 이전에 먼저 노출되어 UX를 해치기에 clear에 가까운 색상으로 눈속임을 진행했습니다.**


## 📸 ScreenShot


https://github.com/YAPP-Github/Coffice-iOS/assets/67148595/92868995-62b8-42dd-bb3f-95721d334d7e



#### Linked Issue

close #137 
