### PR TITLE
Feature/#131 상세화면 맵뷰 추가

### DIFF
--- a/Projects/Coffice/Project.swift
+++ b/Projects/Coffice/Project.swift
@@ -31,6 +31,9 @@ let project = Project.app(
         "CFBundleTypeRole": "Editor",
         "CFBundleURLSchemes": ["kakao$(KAKAO_NATIVE_APP_KEY)"]
       ]
+    ],
+    "NSAppTransportSecurity": [
+      "NSAllowsArbitraryLoads": true
     ]
   ],
   dependencies: [

--- a/Projects/Coffice/Sources/App/Main/MainCoordinatorView.swift
+++ b/Projects/Coffice/Sources/App/Main/MainCoordinatorView.swift
@@ -49,6 +49,7 @@ struct MainCoordinatorView: View {
           }
           .tag(TabBar.State.TabBarItemType.myPage)
         }
+        .padding(.bottom, 16)
         .overlay(alignment: .bottom) {
           if viewStore.shouldShowTabBarView {
             TabBarView(

--- a/Projects/Coffice/Sources/App/Main/Search/CafeFilterMenusView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeFilterMenusView.swift
@@ -67,7 +67,8 @@ struct CafeFilterMenusView: View {
           }
           .padding(.horizontal, 20)
         }
-        .frame(width: 355, height: 36)
+        .frame(maxWidth: .infinity)
+        .frame(height: 36)
         .padding(.bottom, 16)
       }
       .onAppear {

--- a/Projects/Coffice/Sources/App/Main/Search/CafeMapView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeMapView.swift
@@ -144,12 +144,7 @@ extension CafeMapView {
           }
         }
       }
-      .padding(
-        .bottom,
-        viewStore.selectedCafe == nil
-        ? TabBarSizePreferenceKey.defaultValue.height + 24
-        : 24
-      )
+      .padding(.bottom, 24)
     }
   }
 

--- a/Projects/Coffice/Sources/App/Main/Search/Detail/CafeDetailNaverMapView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/CafeDetailNaverMapView.swift
@@ -1,0 +1,73 @@
+//
+//  CafeDetailNaverMapView.swift
+//  coffice
+//
+//  Created by 천수현 on 2023/07/12.
+//  Copyright © 2023 kr.co.yapp. All rights reserved.
+//
+
+import ComposableArchitecture
+import NMapsMap
+import SwiftUI
+
+struct CafeDetailNaverMapView {
+  @ObservedObject var viewStore: ViewStoreOf<CafeSearchDetail>
+
+  init(viewStore: ViewStoreOf<CafeSearchDetail>) {
+    self.viewStore = viewStore
+  }
+}
+
+extension CafeDetailNaverMapView: UIViewRepresentable {
+  func makeUIView(context: Context) -> NMFNaverMapView {
+    let naverMapView = NMFNaverMapView()
+    naverMapView.showScaleBar = false
+    naverMapView.showZoomControls = false
+    naverMapView.showLocationButton = false
+    naverMapView.mapView.positionMode = .direction
+    naverMapView.mapView.locationOverlay.hidden = false
+    naverMapView.mapView.allowsScrolling = false
+    naverMapView.mapView.allowsZooming = false
+    naverMapView.mapView.allowsRotating = false
+    naverMapView.mapView.allowsTilting = false
+    return naverMapView
+  }
+
+  func updateUIView(_ uiView: NMFNaverMapView, context: Context) {
+    if let cafe = viewStore.cafe {
+      addMarker(
+        naverMapView: uiView,
+        latitude: cafe.latitude,
+        longitude: cafe.longitude,
+        coordinator: context.coordinator
+      )
+    }
+  }
+
+  func makeCoordinator() -> Coordinator {
+    return Coordinator(target: self)
+  }
+}
+
+extension CafeDetailNaverMapView {
+  func addMarker(naverMapView: NMFNaverMapView, latitude: Double, longitude: Double, coordinator: Coordinator) {
+    let marker = NMFMarker(position: NMGLatLng(lat: latitude, lng: longitude))
+    marker.iconImage = NMFOverlayImage(image: CofficeAsset.Asset.mapPinFill24px.image)
+    marker.width = 24
+    marker.height = 24
+    marker.mapView = naverMapView.mapView
+    let nmgLocation = NMGLatLng(lat: latitude, lng: longitude)
+    let cameraUpdate = NMFCameraUpdate(scrollTo: nmgLocation, zoomTo: 15.5)
+    naverMapView.mapView.moveCamera(cameraUpdate)
+  }
+}
+
+extension CafeDetailNaverMapView {
+  class Coordinator: NSObject, NMFMapViewOptionDelegate {
+    var target: CafeDetailNaverMapView
+
+    init(target: CafeDetailNaverMapView) {
+      self.target = target
+    }
+  }
+}

--- a/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailMenuView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailMenuView.swift
@@ -107,10 +107,9 @@ extension CafeSearchDetailMenuView {
   }
 
   private var mapInfoView: some View {
-    WithViewStore(store) { _ in
-      // TODO: 지도 뷰 추가 필요
-      Color.black
-        .frame(height: 126)
+    WithViewStore(store) { viewStore in
+      CafeDetailNaverMapView(viewStore: viewStore)
+        .frame(height: 123)
     }
   }
 

--- a/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailView.swift
@@ -29,10 +29,6 @@ struct CafeSearchDetailView: View {
             CafeSearchDetailSubInfoView(store: store)
             CafeSearchDetailMenuView(store: store)
           }
-          .padding(
-            .bottom,
-            (UIApplication.keyWindow?.safeAreaInsets.bottom ?? 0.0)
-          )
         }
       }
       .navigationBarHidden(true)

--- a/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/Detail/CafeSearchDetailView.swift
@@ -31,8 +31,7 @@ struct CafeSearchDetailView: View {
           }
           .padding(
             .bottom,
-            TabBarSizePreferenceKey.defaultValue.height
-            + (UIApplication.keyWindow?.safeAreaInsets.bottom ?? 0.0)
+            (UIApplication.keyWindow?.safeAreaInsets.bottom ?? 0.0)
           )
         }
       }


### PR DESCRIPTION
## ☕️ PR 요약
- 카페 상세화면에 맵뷰를 추가했습니다.
- 필터 메뉴뷰의 레이아웃을 피그마에 맞게 수정했습니다.
- 커스텀 탭바가 시스템 기본 탭바의 높이보다 16px 높아서 하단 컨텐츠를 가리던 문제를 TabView에 패딩을 주어 해결했습니다.

## 📸 ScreenShot
<img src = "https://github.com/YAPP-Github/Coffice-iOS/assets/67148595/c5412e31-8c38-46bf-a8fa-bb2ebd4fafc9" width="50%" height="50%">


#### Linked Issue

close #131 
