### PR TITLE
[Feat] 카페 상세 > 리뷰 목록 관련 팝업 (신고, 수정, 삭제) 표출로직 구성

### DIFF
--- a/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailMenuView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailMenuView.swift
@@ -313,15 +313,19 @@ extension CafeDetailMenuView {
                 Spacer()
 
                 VStack {
-                  Button {
-                    // TODO: 수정/삭제 & 신고하기 이벤트 구현 필요
-                  } label: {
-                    if Int.random(in: 0...1) == 0 {
-                      CofficeAsset.Asset.more2Fill24px.swiftUIImage
-                    } else {
+                  if viewState.isMyReview {
+                    Button {
+                      viewStore.send(.reviewModifyPopup(isPresented: true))
+                    } label: {
                       Text("수정/삭제")
                         .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
                         .applyCofficeFont(font: .body2Medium)
+                    }
+                  } else {
+                    Button {
+                      viewStore.send(.reviewReportPopup(isPresented: true))
+                    } label: {
+                      CofficeAsset.Asset.more2Fill24px.swiftUIImage
                     }
                   }
                   Spacer()

--- a/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailMenuView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailMenuView.swift
@@ -342,25 +342,27 @@ extension CafeDetailMenuView {
             .padding(.top, 20)
 
             // TODO: Tag기 한줄 넘어갈 경우 넘어가도록 커스텀 뷰 구현 필요
-            HStack(spacing: 8) {
-              ForEach(viewState.tagTypes, id: \.self) { tagType in
-                Text(tagType.title)
-                  .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
-                  .applyCofficeFont(font: .body2Medium)
-                  .frame(height: 18)
-                  .padding(.vertical, 4)
-                  .padding(.horizontal, 8)
-                  .overlay(
-                    RoundedRectangle(cornerRadius: 4)
-                      .stroke(
-                        CofficeAsset.Colors.grayScale3.swiftUIColor,
-                        lineWidth: 1
-                      )
-                  )
+            if viewState.tagTypes.isNotEmpty {
+              HStack(spacing: 8) {
+                ForEach(viewState.tagTypes, id: \.self) { tagType in
+                  Text(tagType.title)
+                    .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
+                    .applyCofficeFont(font: .body2Medium)
+                    .frame(height: 18)
+                    .padding(.vertical, 4)
+                    .padding(.horizontal, 8)
+                    .overlay(
+                      RoundedRectangle(cornerRadius: 4)
+                        .stroke(
+                          CofficeAsset.Colors.grayScale3.swiftUIColor,
+                          lineWidth: 1
+                        )
+                    )
+                }
               }
+              .frame(height: 26)
+              .padding(.top, 20)
             }
-            .frame(height: 26)
-            .padding(.top, 20)
 
             CofficeAsset.Colors.grayScale3.swiftUIColor
               .frame(height: 1)

--- a/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailMenuView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailMenuView.swift
@@ -315,7 +315,7 @@ extension CafeDetailMenuView {
                 VStack {
                   if viewState.isMyReview {
                     Button {
-                      viewStore.send(.reviewModifyPopup(isPresented: true))
+                      viewStore.send(.reviewModifyButtonTapped(viewState: viewState))
                     } label: {
                       Text("수정/삭제")
                         .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)

--- a/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailView.swift
@@ -112,6 +112,9 @@ struct CafeDetailView: View {
             .isOpaque(true)
             .closeOnTapOutside(true)
             .backgroundColor(CofficeAsset.Colors.grayScale10.swiftUIColor.opacity(0.4))
+            .dismissCallback {
+              viewStore.send(.reviewModifyPopupDismissed)
+            }
         }
       )
       .popup(

--- a/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailView.swift
@@ -73,6 +73,78 @@ struct CafeDetailView: View {
           )
         }
       )
+      .popup(
+        isPresented: viewStore.binding(\.$isReviewModifyPopupPresented),
+        view: {
+          VStack(spacing: 12) {
+            Button {
+              viewStore.send(.reviewEditButtonTapped)
+            } label: {
+              Text("수정하기")
+                .foregroundColor(CofficeAsset.Colors.grayScale9.swiftUIColor)
+                .applyCofficeFont(font: .button)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(height: 52)
+                .padding(.top, 20)
+            }
+
+            Button {
+              viewStore.send(.reviewDeleteButtonTapped)
+            } label: {
+              Text("삭제하기")
+                .foregroundColor(CofficeAsset.Colors.grayScale9.swiftUIColor)
+                .applyCofficeFont(font: .button)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(height: 52)
+            }
+
+            Spacer()
+          }
+          .padding(.horizontal, 20)
+          .frame(height: 196)
+          .background(CofficeAsset.Colors.grayScale1.swiftUIColor)
+          .cornerRadius(12, corners: [.topLeft, .topRight])
+        },
+        customize: { popup in
+          popup
+            .type(.toast)
+            .position(.bottom)
+            .isOpaque(true)
+            .closeOnTapOutside(true)
+            .backgroundColor(CofficeAsset.Colors.grayScale10.swiftUIColor.opacity(0.4))
+        }
+      )
+      .popup(
+        isPresented: viewStore.binding(\.$isReviewReportPopupPresented),
+        view: {
+          VStack(spacing: 12) {
+            Button {
+              viewStore.send(.reviewReportButtonTapped)
+            } label: {
+              Text("신고하기")
+                .foregroundColor(CofficeAsset.Colors.grayScale9.swiftUIColor)
+                .applyCofficeFont(font: .button)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(height: 52)
+                .padding(.top, 20)
+            }
+
+            Spacer()
+          }
+          .padding(.horizontal, 20)
+          .frame(height: 132)
+          .background(CofficeAsset.Colors.grayScale1.swiftUIColor)
+          .cornerRadius(12, corners: [.topLeft, .topRight])
+        },
+        customize: { popup in
+          popup
+            .type(.toast)
+            .position(.bottom)
+            .isOpaque(true)
+            .closeOnTapOutside(true)
+            .backgroundColor(CofficeAsset.Colors.grayScale10.swiftUIColor.opacity(0.4))
+        }
+      )
     }
   }
 }


### PR DESCRIPTION
## ☕️ PR 요약
- 카페상세 > 리뷰목록에서 표출되는 수정/삭제/신고 옵션버튼이 있는 팝업 표출 로직을 구성했습니다.
  - 자신이 작성한 리뷰는 삭제/수정 옵션이, 자신이 작성한 리뷰가 아니면 신고하기 옵션이 표출됩니다.
- todo
  - 리뷰 삭제/신고 기능 구현 예정입니다.
  - 카페상세 Reducer가 많이 커서 추후에 Reducer 분리작업을 진행할 생각입니다.
  - 리뷰작성화면에서 텍스트 입력 후 에러 로그가 남는 증상이 있어서 수정 예정입니다.


## 📸 ScreenShot
- 리뷰 수정/삭제/신고 팝업 표출 UI, 이벤트 구성 | 리뷰 수정 플로우 구성 (리뷰 수정 API 연동)
<div>
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/6dc7aa5b-45d3-4add-946e-3a6196be4331" width="200">
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/6e2f7a22-59ad-4724-80d7-24f2764314e1" width="200">
</div>

##### ✅ PR check list(PR 요청시 확인후 삭제해주세요)

```
- commit message가 적절한지 확인해주세요.
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```



#### Linked Issue

related #161 #139
