### PR TITLE
Feature/#178 닉네임 검사 로직 제작

### DIFF
--- a/Projects/Coffice/Sources/App/Dependencies/CheckNicknameAPIClient.swift
+++ b/Projects/Coffice/Sources/App/Dependencies/CheckNicknameAPIClient.swift
@@ -1,0 +1,41 @@
+//
+//  CheckNicknameAPIClient.swift
+//  coffice
+//
+//  Created by 천수현 on 2023/07/16.
+//  Copyright © 2023 kr.co.yapp. All rights reserved.
+//
+
+import Dependencies
+import Foundation
+import Network
+
+struct CheckNicknameAPIClient: DependencyKey {
+  static var liveValue: CheckNicknameAPIClient = .liveValue
+
+  func checkNickname(nickName: String) async throws -> CheckNicknameResponse {
+    let coreNetwork = CoreNetwork.shared
+    var urlComponents = URLComponents(string: coreNetwork.baseURL)
+    urlComponents?.path = "/api/v1/members/me/name"
+
+    guard let requestBody = try? JSONEncoder().encode(CheckNicknameRequestDTO(name: nickName))
+    else { throw CoreNetworkError.jsonEncodeFailed }
+
+    guard let request = urlComponents?.toURLRequest(
+      method: .put,
+      httpBody: requestBody
+    ) else {
+      throw CoreNetworkError.requestConvertFailed
+    }
+
+    let result: NetworkResult<MemberResponseDTO> = try await coreNetwork.networkResult(request: request)
+    return CheckNicknameResponse.response(of: result)
+  }
+}
+
+extension DependencyValues {
+  var checkNicknameAPIClient: CheckNicknameAPIClient {
+    get { self[CheckNicknameAPIClient.self] }
+    set { self[CheckNicknameAPIClient.self] = newValue }
+  }
+}

--- a/Projects/Coffice/Sources/App/Entities/CheckNicknameResponse.swift
+++ b/Projects/Coffice/Sources/App/Entities/CheckNicknameResponse.swift
@@ -1,0 +1,69 @@
+//
+//  CheckNicknameResponse.swift
+//  coffice
+//
+//  Created by 천수현 on 2023/07/16.
+//  Copyright © 2023 kr.co.yapp. All rights reserved.
+//
+
+import Foundation
+import Network
+
+enum CheckNicknameResponse {
+  case valid
+  case duplicated
+  case tooShort
+  case tooLong
+  case isEmpty
+  case containsIllegalCharacters
+  case unknownError
+
+  var serverCode: String {
+    switch self {
+    case .valid:
+      return "SUCCESS"
+    case .duplicated:
+      return "MEMBER_NAME_DUPLICATED"
+    case .tooShort:
+      return "MEMBER_NAME_LENGTH_TOO_SHORT"
+    case .tooLong:
+      return "MEMBER_NAME_LENGTH_TOO_LONG"
+    case .isEmpty:
+      return "MEMBER_NAME_EMPTY"
+    case .containsIllegalCharacters:
+      return "MEMBER_NAME_CONTAINS_ILLEGAL_CHARACTERS"
+    case .unknownError:
+      return "UNKNOWN_ERROR"
+    }
+  }
+
+  var warningMessage: String {
+    switch self {
+    case .duplicated:
+      return "이미 존재하는 닉네임입니다."
+    case .tooLong, .tooShort:
+      return "한글/영어/숫자 최소 2자, 최대 15자로 입력해주세요."
+    default:
+      return ""
+    }
+  }
+
+  static func response(of networkResult: NetworkResult<MemberResponseDTO>) -> CheckNicknameResponse {
+    switch networkResult.code {
+    case "SUCCESS":
+      return .valid
+    case "MEMBER_NAME_DUPLICATED":
+      return .duplicated
+    case "MEMBER_NAME_LENGTH_TOO_SHORT":
+      return .tooShort
+    case "MEMBER_NAME_LENGTH_TOO_LONG":
+      return .tooLong
+    case "MEMBER_NAME_EMPTY":
+      return .isEmpty
+    case "MEMBER_NAME_CONTAINS_ILLEGAL_CHARACTERS":
+      return .containsIllegalCharacters
+    default:
+      return .unknownError
+    }
+  }
+}

--- a/Projects/Network/Sources/DTOs/Requests/CheckNicknameRequestDTO.swift
+++ b/Projects/Network/Sources/DTOs/Requests/CheckNicknameRequestDTO.swift
@@ -1,0 +1,17 @@
+//
+//  CheckNicknameRequestDTO.swift
+//  Network
+//
+//  Created by 천수현 on 2023/07/16.
+//  Copyright © 2023 kr.co.yapp. All rights reserved.
+//
+
+import Foundation
+
+public struct CheckNicknameRequestDTO: Encodable {
+  public let name: String
+
+  public init(name: String) {
+    self.name = name
+  }
+}

--- a/Projects/Network/Sources/NetworkResult.swift
+++ b/Projects/Network/Sources/NetworkResult.swift
@@ -8,13 +8,13 @@
 
 import Foundation
 
-struct NetworkResult<DTO: Decodable>: Decodable {
-  let code: String
-  let message: String
-  let data: DTO
-  let page: PageResponse?
+public struct NetworkResult<DTO: Decodable>: Decodable {
+  public let code: String
+  public let message: String
+  public let data: DTO?
+  public let page: PageResponse?
 
-  struct PageResponse: Decodable {
-    let hasNext: Bool?
+  public struct PageResponse: Decodable {
+    public let hasNext: Bool?
   }
 }


### PR DESCRIPTION
## ☕️ PR 요약
- CheckNicknameAPIClient 제작

### 참고사항
- network result 파싱 구조 변경 예정
- 현재 배포가 코앞이기에 기존 구조는 건드리지 않고 닉네임 검사를 위한 임시 구조 제작하여 사용하였습니다.

#### Linked Issue

close #178 
