### PR TITLE
[Refactor] 필터 바텀 시트 뷰, 카페 상세화면을 통한 말풍선 뷰 표출방식 수정

### DIFF
--- a/Projects/Coffice/Sources/App/Main/MainCoordinatorCore.swift
+++ b/Projects/Coffice/Sources/App/Main/MainCoordinatorCore.swift
@@ -30,7 +30,6 @@ struct MainCoordinator: ReducerProtocol {
 
     var filterSheetState: CafeFilterBottomSheet.State?
     var commonBottomSheetState: CommonBottomSheet.State?
-    var bubbleMessageState: BubbleMessage.State?
 
     var shouldShowTabBarView = true
   }
@@ -44,9 +43,7 @@ struct MainCoordinator: ReducerProtocol {
     case tabBar(TabBar.Action)
     case filterBottomSheet(action: CafeFilterBottomSheet.Action)
     case commonBottomSheet(action: CommonBottomSheet.Action)
-    case bubbleMessage(BubbleMessage.Action)
     case dismissToastMessageView
-    case dismissBubbleMessageView
     case onAppear
   }
 
@@ -120,16 +117,6 @@ struct MainCoordinator: ReducerProtocol {
         state.filterSheetState = filterSheetState
         return .none
 
-      case .search(.routeAction(_, .cafeSearchDetail(.presentBubbleMessageView(let bubbleMessageState)))),
-          .filterBottomSheet(.presentBubbleMessageView(let bubbleMessageState)):
-        state.shouldShowTabBarView = false
-        state.bubbleMessageState = bubbleMessageState
-        return .none
-
-      case .dismissBubbleMessageView:
-        state.shouldShowTabBarView = true
-        state.bubbleMessageState = nil
-        return .none
       case .myPage(.routeAction(_, .editProfile(.hideTabBar))):
         state.shouldShowTabBarView = false
         return .none

--- a/Projects/Coffice/Sources/App/Main/MainCoordinatorView.swift
+++ b/Projects/Coffice/Sources/App/Main/MainCoordinatorView.swift
@@ -77,17 +77,6 @@ struct MainCoordinatorView: View {
             ),
             then: CommonBottomSheetView.init
           )
-
-          IfLetStore(
-            store.scope(
-              state: \.bubbleMessageState,
-              action: MainCoordinator.Action.bubbleMessage
-            ),
-            then: BubbleMessageView.init
-          )
-          .onTapGesture {
-            viewStore.send(.dismissBubbleMessageView)
-          }
         }
         .onAppear {
           viewStore.send(.onAppear)

--- a/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailCore.swift
@@ -17,6 +17,7 @@ struct CafeDetail: ReducerProtocol {
     @BindingState var isReviewDeleteConfirmSheetPresented = false
     @BindingState var deleteConfirmBottomSheetState: BottomSheetReducer.State?
     @BindingState var toastViewMessage: String?
+    @BindingState var bubbleMessageViewState: BubbleMessage.State?
     var bottomSheetType: BottomSheetType = .deleteConfirm
 
     var cafeId: Int
@@ -93,6 +94,7 @@ struct CafeDetail: ReducerProtocol {
     case infoGuideButtonTapped(CafeFilter.GuideType)
     case presentBubbleMessageView(BubbleMessage.State)
     case presentCafeReviewWriteView(CafeReviewWrite.State)
+    case bubbleMessageAction(BubbleMessage.Action)
     case presentToastView(message: String)
     case cafeReviewWrite(action: CafeReviewWrite.Action)
     case bottomSheet(action: BottomSheetReducer.Action)
@@ -279,6 +281,10 @@ struct CafeDetail: ReducerProtocol {
             .init(guideType: guideType)
           )
         )
+
+      case .presentBubbleMessageView(let viewState):
+        state.bubbleMessageViewState = viewState
+        return .none
 
       case .cafeReviewWrite(let action):
         switch action {

--- a/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailView.swift
@@ -176,6 +176,24 @@ struct CafeDetailView: View {
             .autohideIn(2)
         }
       )
+      .popup(
+        item: viewStore.binding(\.$bubbleMessageViewState),
+        itemView: { viewState in
+          BubbleMessageView(store: store.scope(
+            state: { _ in viewState },
+            action: CafeDetail.Action.bubbleMessageAction)
+          )
+        },
+        customize: { popup in
+          popup
+            .type(.default)
+            .position(.center)
+            .animation(.easeIn(duration: 0))
+            .isOpaque(true)
+            .closeOnTapOutside(true)
+            .backgroundColor(CofficeAsset.Colors.grayScale10.swiftUIColor.opacity(0.4))
+        }
+      )
     }
   }
 }

--- a/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheet.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheet.swift
@@ -18,6 +18,7 @@ struct CafeFilterBottomSheet: ReducerProtocol {
       )
     }
 
+    @BindingState var bubbleMessageViewState: BubbleMessage.State?
     let filterType: CafeFilter.MenuType
     var guideType: CafeFilter.GuideType? {
       switch filterType {
@@ -56,7 +57,8 @@ struct CafeFilterBottomSheet: ReducerProtocol {
     }
   }
 
-  enum Action: Equatable {
+  enum Action: Equatable, BindableAction {
+    case binding(BindingAction<State>)
     case dismiss
     /// dismiss 애니메이션 적용을 위해 딜레이 시간을 적용한 이벤트
     case dismissWithDelay
@@ -72,11 +74,14 @@ struct CafeFilterBottomSheet: ReducerProtocol {
     case backgroundViewTapped
     case updateContainerView(height: CGFloat)
     case saveCafeFilter(information: CafeFilterInformation)
+    case bubbleMessageAction(BubbleMessage.Action)
   }
 
   @Dependency(\.placeAPIClient) private var placeAPIClient
 
   var body: some ReducerProtocolOf<CafeFilterBottomSheet> {
+    BindingReducer()
+
     Reduce { state, action in
       switch action {
       case .backgroundViewTapped:
@@ -146,6 +151,10 @@ struct CafeFilterBottomSheet: ReducerProtocol {
             .init(guideType: guideType)
           )
         )
+
+      case .presentBubbleMessageView(let viewState):
+        state.bubbleMessageViewState = viewState
+        return .none
 
       case .updateMainViewState:
         state.updateMainViewState()

--- a/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheetView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheetView.swift
@@ -51,6 +51,24 @@ struct CafeFilterBottomSheetView: View {
         }
         .frame(width: proxy.size.width, height: proxy.size.height)
         .animation(.easeIn(duration: viewStore.dismissAnimationDuration), value: viewStore.isBottomSheetPresented)
+        .popup(
+          item: viewStore.binding(\.$bubbleMessageViewState),
+          itemView: { viewState in
+            BubbleMessageView(store: store.scope(
+              state: { _ in viewState },
+              action: CafeFilterBottomSheet.Action.bubbleMessageAction)
+            )
+          },
+          customize: { popup in
+            popup
+              .type(.default)
+              .position(.center)
+              .animation(.easeIn(duration: 0))
+              .isOpaque(true)
+              .closeOnTapOutside(true)
+              .backgroundColor(CofficeAsset.Colors.grayScale10.swiftUIColor.opacity(0.4))
+          }
+        )
       }
     }
   }


### PR DESCRIPTION
## ☕️ PR 요약
- 필터 바텀 시트 뷰, 카페 상세화면을 통한 말풍선 뷰 표출방식을 수정했습니다. (기존 로직에서 북마크를 통한 카페상세 진입 시 말풍선 뷰 표출이 안되는 문제 존재)
  - MainCoordinator의 bubbleMssage 관련 코드 제거 후 PopupView 라이브러리 적용
- todo:
  - 말풍선 뷰 표출 시, 하단 safe area에 흰색 패딩이 남아있는 문제가 있어서 원인 확인 및 수정 예정입니다. 



## 📸 ScreenShot
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/e5c67e84-9156-461c-908a-467dca53d9c6" width="200">



##### ✅ PR check list(PR 요청시 확인후 삭제해주세요)

```
- commit message가 적절한지 확인해주세요.
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```



#### Linked Issue

close #181 
