### PR TITLE
[Fix] #183 검색 플로우 수정

### DIFF
--- a/Projects/Coffice/Sources/App/Main/Search/CafeSearch/CafeSearchCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeSearch/CafeSearchCore.swift
@@ -69,7 +69,7 @@ struct CafeSearchCore: ReducerProtocol {
   enum CafeSearchCoreDelegate: Equatable {
     case callSearchWithRequestValueByText(searchText: String)
     case searchWithRequestValueByWaypoint(waypoint: WayPoint)
-    case focusSelectedPlace(selectedPlace: Cafe)
+    case focusSelectedPlace(selectedPlace: [Cafe])
     case dismiss
   }
 
@@ -118,7 +118,7 @@ struct CafeSearchCore: ReducerProtocol {
         return EffectTask(value: .delegate(.searchWithRequestValueByWaypoint(waypoint: waypoint)))
 
       case .placeCellTapped(let place):
-        return EffectTask(value: .delegate(.focusSelectedPlace(selectedPlace: place)))
+        return EffectTask(value: .delegate(.focusSelectedPlace(selectedPlace: [place])))
 
       case .clearTextButtonTapped:
         state.searchText = ""
@@ -138,7 +138,6 @@ struct CafeSearchCore: ReducerProtocol {
 
       case .submitText:
         guard state.searchText.isNotEmpty else { return .none }
-
         return .run { [searchText = state.searchText] send in
           let waypoints = try await placeAPIClient.fetchWaypoints(name: searchText)
           if let waypoint = waypoints.first {
@@ -206,11 +205,11 @@ struct CafeSearchCore: ReducerProtocol {
         return .none
 
       case .searchPlacesWithRequestValueResponse(let cafes):
-        guard let cafe = cafes.first else {
+        guard cafes.isNotEmpty else {
           state.bodyType = .searchResultEmptyView
           return .none
         }
-        return EffectTask(value: .delegate(.focusSelectedPlace(selectedPlace: cafe)))
+        return EffectTask(value: .delegate(.focusSelectedPlace(selectedPlace: cafes)))
 
       default:
         return .none


### PR DESCRIPTION
## ☕️ PR 요약

### as is
- 카페 검색 시, "강남역", "강남" 입력 후 연관검색어로 셀을 클릭하거나 엔터를 입력했을 시,
   해당 위치로 화면전환이 이루어지지 않는 상황

- 필터 검색 로직이 제거되어, 필터 반영이 이루어지지 않는 상황

- 카페 검색 시, ex) "스타벅스" 입력 후 검색 -> 단일 카페만 화면에 표출되는 상황

### to be
- 카페 검색 시, "강남역", "강남" 입력 후 연관검색어로 셀을 클릭하거나 엔터를 입력했을 시,
해당 위치로 화면전환이 이루어지며, 주위 카페목록을 표출

- 필터 검색 로직 추가, 필터 반영

- 카페 검색 시, ex) "스타벅스" 입력 후 검색 -> 조건에 충족하는 카페 화면에 표출

## 📸 ScreenShot

![Simulator Screen Recording - iPhone 12 mini - 2023-07-16 at 17 37 15](https://github.com/YAPP-Github/Coffice-iOS/assets/108966759/b228c8b5-434e-44a8-bec5-ed30ce61532a)


#### Linked Issue

close #183 
