### PR TITLE
Feature/#190 필터 bottom sheet 표출 및 필터 설정 로직 개선 (PopupView Library 적용)

### DIFF
--- a/Projects/Coffice/Sources/App/Main/MainCoordinatorCore.swift
+++ b/Projects/Coffice/Sources/App/Main/MainCoordinatorCore.swift
@@ -28,7 +28,6 @@ struct MainCoordinator: ReducerProtocol {
     var myPageState: MyPageCoordinator.State
     var tabBarState: TabBar.State
 
-    var filterSheetState: CafeFilterBottomSheet.State?
     var commonBottomSheetState: CommonBottomSheet.State?
 
     var shouldShowTabBarView = true
@@ -41,7 +40,6 @@ struct MainCoordinator: ReducerProtocol {
     case savedList(SavedListCoordinator.Action)
     case myPage(MyPageCoordinator.Action)
     case tabBar(TabBar.Action)
-    case filterBottomSheet(action: CafeFilterBottomSheet.Action)
     case commonBottomSheet(action: CommonBottomSheet.Action)
     case dismissToastMessageView
     case onAppear
@@ -71,29 +69,6 @@ struct MainCoordinator: ReducerProtocol {
 
     Reduce { state, action in
       switch action {
-      case .filterBottomSheet(.dismiss):
-        state.shouldShowTabBarView = true
-        state.filterSheetState = nil
-        return .none
-
-      case .filterBottomSheet(.saveCafeFilter(let information)):
-        return EffectTask(
-          value: .search(
-            .routeAction(0, action: .cafeMap(.updateCafeFilter(information: information)))
-          )
-        )
-
-      case .filterBottomSheet(.dismissWithDelay):
-        return .merge(
-          EffectTask(value: .search(.routeAction(
-            0,
-            action: .cafeMap(.filterBottomSheetDismissed)
-          ))),
-          EffectTask(value: .search(.routeAction(
-            0,
-            action: .cafeMap(.cafeSearchListAction(.filterBottomSheetDismissed))
-          )))
-        )
 
       case .commonBottomSheet(.dismiss):
         state.commonBottomSheetState = nil
@@ -106,16 +81,6 @@ struct MainCoordinator: ReducerProtocol {
         debugPrint("selectedTab : \(itemType)")
         return .none
 
-      case
-          .search(.routeAction(_, .cafeMap(.cafeFilterMenusAction(
-            .presentFilterBottomSheetView(let filterSheetState)
-          )))),
-          .search(.routeAction(_, .cafeMap(.cafeSearchListAction(.cafeFilterMenus(
-            action: .presentFilterBottomSheetView(let filterSheetState)
-          ))))):
-        state.shouldShowTabBarView = false
-        state.filterSheetState = filterSheetState
-        return .none
 
       case .myPage(.routeAction(_, .editProfile(.hideTabBar))):
         state.shouldShowTabBarView = false
@@ -128,12 +93,6 @@ struct MainCoordinator: ReducerProtocol {
       default:
         return .none
       }
-    }
-    .ifLet(
-      \.filterSheetState,
-      action: /Action.filterBottomSheet
-    ) {
-      CafeFilterBottomSheet()
     }
     .ifLet(
       \.commonBottomSheetState,

--- a/Projects/Coffice/Sources/App/Main/MainCoordinatorView.swift
+++ b/Projects/Coffice/Sources/App/Main/MainCoordinatorView.swift
@@ -64,14 +64,6 @@ struct MainCoordinatorView: View {
 
           IfLetStore(
             store.scope(
-              state: \.filterSheetState,
-              action: MainCoordinator.Action.filterBottomSheet
-            ),
-            then: CafeFilterBottomSheetView.init
-          )
-
-          IfLetStore(
-            store.scope(
               state: \.commonBottomSheetState,
               action: MainCoordinator.Action.commonBottomSheet
             ),

--- a/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheet.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheet.swift
@@ -41,8 +41,6 @@ struct CafeFilterBottomSheet: ReducerProtocol {
     var originCafeFilterInformation: CafeFilterInformation
     var cafeFilterInformation: CafeFilterInformation
     var mainViewState: CafeFilterBottomSheetViewState = .init(optionButtonCellViewStates: [])
-    let dismissAnimationDuration: Double = 0.3
-    let dismissDelayNanoseconds: UInt64 = 300_000_000
     var containerViewHeight: CGFloat = .zero
     let headerViewHeight: CGFloat = 80
     let footerViewHeight: CGFloat = 84 + (UIApplication.keyWindow?.safeAreaInsets.bottom ?? 0.0)
@@ -163,7 +161,6 @@ struct CafeFilterBottomSheet: ReducerProtocol {
         return EffectTask(value: .updateMainViewState)
 
       case .saveCafeFilterButtonTapped:
-        debugPrint("saved mainViewState : \(state.mainViewState)")
         return EffectTask(value: .saveCafeFilter(information: state.cafeFilterInformation))
 
       case .updateContainerView(let height):

--- a/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheet.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheet.swift
@@ -41,8 +41,6 @@ struct CafeFilterBottomSheet: ReducerProtocol {
     var originCafeFilterInformation: CafeFilterInformation
     var cafeFilterInformation: CafeFilterInformation
     var mainViewState: CafeFilterBottomSheetViewState = .init(optionButtonCellViewStates: [])
-
-    var isBottomSheetPresented = false
     let dismissAnimationDuration: Double = 0.3
     let dismissDelayNanoseconds: UInt64 = 300_000_000
     var containerViewHeight: CGFloat = .zero
@@ -60,8 +58,6 @@ struct CafeFilterBottomSheet: ReducerProtocol {
   enum Action: Equatable, BindableAction {
     case binding(BindingAction<State>)
     case dismiss
-    /// dismiss 애니메이션 적용을 위해 딜레이 시간을 적용한 이벤트
-    case dismissWithDelay
     case presentBottomSheet
     case hideBottomSheet
     case optionButtonTapped(optionType: CafeFilter.OptionType)
@@ -71,7 +67,6 @@ struct CafeFilterBottomSheet: ReducerProtocol {
     case resetCafeFilterButtonTapped
     case resetCafeFilter
     case saveCafeFilterButtonTapped
-    case backgroundViewTapped
     case updateContainerView(height: CGFloat)
     case saveCafeFilter(information: CafeFilterInformation)
     case bubbleMessageAction(BubbleMessage.Action)
@@ -84,17 +79,6 @@ struct CafeFilterBottomSheet: ReducerProtocol {
 
     Reduce { state, action in
       switch action {
-      case .backgroundViewTapped:
-        return EffectTask(value: .dismissWithDelay)
-
-      case .hideBottomSheet:
-        state.isBottomSheetPresented = false
-        return .none
-
-      case .presentBottomSheet:
-        state.isBottomSheetPresented = true
-        return .none
-
       case .optionButtonTapped(let optionType):
         switch optionType {
         case .runningTime(let option):
@@ -179,26 +163,12 @@ struct CafeFilterBottomSheet: ReducerProtocol {
         return EffectTask(value: .updateMainViewState)
 
       case .saveCafeFilterButtonTapped:
-        // TODO: 화면 상단 필터뷰로 데이터 전달하여 UI 업데이트 필요
         debugPrint("saved mainViewState : \(state.mainViewState)")
-        return .concatenate(
-          EffectTask(value: .saveCafeFilter(information: state.cafeFilterInformation)),
-          EffectTask(value: .dismissWithDelay)
-        )
+        return EffectTask(value: .saveCafeFilter(information: state.cafeFilterInformation))
 
       case .updateContainerView(let height):
         state.containerViewHeight = height
         return .none
-
-      case .dismissWithDelay:
-        let dismissDelayNanoseconds = Int(state.dismissDelayNanoseconds)
-        state.isBottomSheetPresented = false
-        return .concatenate(
-          EffectTask(value: .hideBottomSheet)
-            .delay(for: .nanoseconds(dismissDelayNanoseconds), scheduler: DispatchQueue.main)
-            .eraseToEffect(),
-          EffectTask(value: .dismiss)
-        )
 
       default:
         return .none

--- a/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheetView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheetView.swift
@@ -18,58 +18,32 @@ struct CafeFilterBottomSheetView: View {
 
   var body: some View {
     WithViewStore(store) { viewStore in
-      GeometryReader { proxy in
-        ZStack {
-          CofficeAsset.Colors.grayScale9.swiftUIColor
-            .opacity(0.4)
-            .ignoresSafeArea()
-            .onTapGesture {
-              viewStore.send(.backgroundViewTapped)
-            }
-            .onAppear {
-              viewStore.send(.presentBottomSheet)
-            }
-
-          if viewStore.isBottomSheetPresented {
-            RoundedRectangle(cornerRadius: 15)
-              .transition(.move(edge: .bottom))
-              .foregroundColor(CofficeAsset.Colors.grayScale1.swiftUIColor)
-              .shadow(color: .gray, radius: 5)
-              .overlay {
-                VStack(spacing: 0) {
-                  filterOptionButtonContainerView
-                  footerView
-                  Spacer()
-                }
-                .frame(width: proxy.size.width, height: proxy.size.height)
-              }
-              .onAppear {
-                viewStore.send(.updateContainerView(height: proxy.size.height))
-              }
-              .offset(y: viewStore.containerViewHeight - viewStore.bottomSheetHeight)
-          }
-        }
-        .frame(width: proxy.size.width, height: proxy.size.height)
-        .animation(.easeIn(duration: viewStore.dismissAnimationDuration), value: viewStore.isBottomSheetPresented)
-        .popup(
-          item: viewStore.binding(\.$bubbleMessageViewState),
-          itemView: { viewState in
-            BubbleMessageView(store: store.scope(
-              state: { _ in viewState },
-              action: CafeFilterBottomSheet.Action.bubbleMessageAction)
-            )
-          },
-          customize: { popup in
-            popup
-              .type(.default)
-              .position(.center)
-              .animation(.easeIn(duration: 0))
-              .isOpaque(true)
-              .closeOnTapOutside(true)
-              .backgroundColor(CofficeAsset.Colors.grayScale10.swiftUIColor.opacity(0.4))
-          }
-        )
+      VStack(spacing: 0) {
+        filterOptionButtonContainerView
+        footerView
       }
+      .background(
+        CofficeAsset.Colors.grayScale1.swiftUIColor
+          .cornerRadius(18, corners: [.topLeft, .topRight])
+      )
+      .popup(
+        item: viewStore.binding(\.$bubbleMessageViewState),
+        itemView: { viewState in
+          BubbleMessageView(store: store.scope(
+            state: { _ in viewState },
+            action: CafeFilterBottomSheet.Action.bubbleMessageAction)
+          )
+        },
+        customize: { popup in
+          popup
+            .type(.default)
+            .position(.center)
+            .animation(.easeIn(duration: 0))
+            .isOpaque(true)
+            .closeOnTapOutside(true)
+            .backgroundColor(CofficeAsset.Colors.grayScale10.swiftUIColor.opacity(0.4))
+        }
+      )
     }
   }
 }
@@ -98,7 +72,7 @@ extension CafeFilterBottomSheetView {
         Spacer()
 
         Button {
-          viewStore.send(.dismissWithDelay)
+          viewStore.send(.dismiss)
         } label: {
           CofficeAsset.Asset.close40px.swiftUIImage
             .padding(.top, 24)
@@ -204,6 +178,7 @@ extension CafeFilterBottomSheetView {
       }
       .frame(height: 84)
       .padding(.horizontal, 20)
+      .padding(.bottom, UIApplication.keyWindow?.safeAreaInsets.bottom ?? 0)
     }
   }
 }

--- a/Projects/Coffice/Sources/App/Main/Search/CafeFilterMenusCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeFilterMenusCore.swift
@@ -67,6 +67,11 @@ struct CafeFilterMenus: ReducerProtocol {
     case cafeFilterBottomSheetViewAction(CafeFilterBottomSheet.Action)
     case updateCafeFilter(information: CafeFilterInformation)
     case updateButtonViewStates
+    case delegate(Delegate)
+  }
+
+  enum Delegate: Equatable {
+    case updateCafeFilter(information: CafeFilterInformation)
   }
 
   var body: some ReducerProtocolOf<CafeFilterMenus> {
@@ -92,6 +97,10 @@ struct CafeFilterMenus: ReducerProtocol {
         state.cafeFilterBottomSheetState = viewState
         return .none
 
+      case .delegate(.updateCafeFilter(let information)):
+        state.filterInformation = information
+        return EffectTask(value: .updateButtonViewStates)
+
       case .updateCafeFilter(let information):
         state.filterInformation = information
         return EffectTask(value: .updateButtonViewStates)
@@ -104,7 +113,7 @@ struct CafeFilterMenus: ReducerProtocol {
         switch action {
         case .saveCafeFilter(let information):
           state.cafeFilterBottomSheetState = nil
-          return EffectTask(value: .updateCafeFilter(information: information))
+          return EffectTask(value: .delegate(.updateCafeFilter(information: information)))
         case .dismiss:
           state.cafeFilterBottomSheetState = nil
           return .none

--- a/Projects/Coffice/Sources/App/Main/Search/CafeFilterMenusView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeFilterMenusView.swift
@@ -73,6 +73,21 @@ struct CafeFilterMenusView: View {
       .onAppear {
         viewStore.send(.onAppear)
       }
+      .popup(
+        item: viewStore.binding(\.$cafeFilterBottomSheetState),
+        itemView: { viewState in
+          CafeFilterBottomSheetView(store: store.scope(
+            state: { _ in viewState },
+            action: CafeFilterMenus.Action.cafeFilterBottomSheetViewAction)
+          )
+        },
+        customize: {
+          BottomSheetContent.customize($0)
+            .dismissCallback {
+              viewStore.send(.updateButtonViewStates)
+            }
+        }
+      )
     }
   }
 }

--- a/Projects/Coffice/Sources/App/Main/Search/CafeSearch/CafeSearchListCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeSearch/CafeSearchListCore.swift
@@ -46,7 +46,6 @@ struct CafeSearchListCore: ReducerProtocol {
     case popView
     case titleLabelTapped
     case updateCafeFilter(information: CafeFilterInformation)
-    case filterBottomSheetDismissed
     case cafeSearchListCellTapped(cafe: Cafe)
     case focusSelectedCafe(selectedCafe: Cafe)
     case searchPlacesByFilter
@@ -110,13 +109,12 @@ struct CafeSearchListCore: ReducerProtocol {
 
       case .updateCafeFilter(let information):
         state.cafeFilterInformation = information
-        return EffectTask(value: .cafeFilterMenus(action: .updateCafeFilter(information: information)))
+        return .none
 
-      case .filterBottomSheetDismissed:
+      case .cafeFilterMenus(.delegate(.updateCafeFilter(let information))):
+        state.cafeFilterInformation = information
         return .concatenate(
-          EffectTask(
-            value: .cafeFilterMenus(action: .updateCafeFilter(information: state.cafeFilterInformation))
-          ),
+          EffectTask(value: .updateCafeFilter(information: information)),
           EffectTask(value: .searchPlacesByFilter)
         )
 


### PR DESCRIPTION
## ☕️ PR 요약
- 필터 bottom sheet 표출 및 필터 설정 로직을 개선했습니다.
  - MainCoordinator의 필터 설정 관련 로직 제거, 실제 표출하는 화면에서 관련 BindingState를 관리
  - PopupView library 적용

## 📸 ScreenShot
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/f327d0a9-e06c-4930-894f-22566734b0f9" width="200">


PR과 관련된 화면을 첨부해주세요.



##### ✅ PR check list(PR 요청시 확인후 삭제해주세요)
- bottom sheet을 통한 필터 설정 정상 동작 여부 확인
- bottom sheet을 통한 말풍선 뷰 표출 로직 정상 동작 확인
- 상단 필터 설정 뷰가 있는 화면 간 필터 설정 데이터 연동 여부 확인

```
- commit message가 적절한지 확인해주세요.
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```



#### Linked Issue

close #190 
