### PR TITLE
Feature/#193 login terms bottom sheet (#197 merge 선행 필요)

### DIFF
--- a/Projects/Coffice/Sources/App/CommonComponents/CommonBottomSheet/BottomSheet.swift
+++ b/Projects/Coffice/Sources/App/CommonComponents/CommonBottomSheet/BottomSheet.swift
@@ -20,6 +20,7 @@ struct BottomSheetContent: Equatable {
       .position(.bottom)
       .isOpaque(true)
       .closeOnTapOutside(true)
+      .closeOnTap(false)
       .backgroundColor(CofficeAsset.Colors.grayScale10.swiftUIColor.opacity(0.4))
   }
   static let mock = BottomSheetContent(

--- a/Projects/Coffice/Sources/App/Login/LoginCore.swift
+++ b/Projects/Coffice/Sources/App/Login/LoginCore.swift
@@ -98,12 +98,12 @@ struct Login: ReducerProtocol {
     // MARK: Login Service Terms Bottom Sheet
     Reduce { state, action in
       switch action {
-      case .loginServiceTermsBottomSheetAction(let action):
+      case .loginServiceTermsBottomSheetAction(.delegate(let action)):
         switch action {
         case .dismissView:
           state.loginServiceTermsBottomSheetState = nil
-        default:
-          return .none
+        case .confirmButtonTapped:
+          state.loginServiceTermsBottomSheetState = nil
         }
         return .none
 

--- a/Projects/Coffice/Sources/App/Login/LoginServiceTermsBottomSheetView.swift
+++ b/Projects/Coffice/Sources/App/Login/LoginServiceTermsBottomSheetView.swift
@@ -29,11 +29,11 @@ struct LoginServiceTermsBottomSheetView: View {
 
         HStack(spacing: 16) {
           Button {
-            // TODO: 약관 전체 동의 이벤트
+            viewStore.send(.wholeTermsAgreementButtonTapped)
           } label: {
-            CofficeAsset.Asset.checkboxCircleLine24px.swiftUIImage
+            viewStore.wholeTermsAgreementCheckboxImage.swiftUIImage
               .renderingMode(.template)
-              .foregroundColor(CofficeAsset.Colors.grayScale4.swiftUIColor)
+              .foregroundColor(viewStore.wholeTermsAgreementCheckboxColor.swiftUIColor)
           }
           Text("약관 전체 동의")
             .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
@@ -47,77 +47,35 @@ struct LoginServiceTermsBottomSheetView: View {
           .frame(height: 1)
           .padding(.bottom, 20)
 
-        HStack(spacing: 16) {
-          Button {
-            // TODO: 약관 동의 이벤트
-          } label: {
-            HStack {
-              CofficeAsset.Asset.checkboxCircleLine24px.swiftUIImage
-                .renderingMode(.template)
-                .foregroundColor(CofficeAsset.Colors.grayScale4.swiftUIColor)
-              Text("서비스 이용약관")
-                .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
-                .applyCofficeFont(font: .subtitle1Medium)
-              Text("(필수)")
-                .foregroundColor(CofficeAsset.Colors.secondary1.swiftUIColor)
-                .applyCofficeFont(font: .subtitle1Medium)
-              Spacer()
+        VStack(spacing: 0) {
+          ForEach(viewStore.termsOptionButtonViewStates) { viewState in
+            HStack(spacing: 16) {
+              Button {
+                viewStore.send(.termsOptionButtonTapped(viewState: viewState))
+              } label: {
+                HStack {
+                  viewState.checkboxImage.swiftUIImage
+                    .renderingMode(.template)
+                    .foregroundColor(viewState.checkboxImageColor.swiftUIColor)
+                  Text(viewState.title)
+                    .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
+                    .applyCofficeFont(font: .subtitle1Medium)
+                  Text("(필수)")
+                    .foregroundColor(CofficeAsset.Colors.secondary1.swiftUIColor)
+                    .applyCofficeFont(font: .subtitle1Medium)
+                  Spacer()
+                }
+                .frame(height: 32)
+              }
+
+              CofficeAsset.Asset.arrowDropRightLine24px.swiftUIImage
             }
-            .frame(height: 32)
+            .padding(.bottom, 20)
           }
-
-          CofficeAsset.Asset.arrowDropRightLine24px.swiftUIImage
         }
-        .padding(.bottom, 20)
-
-        HStack(spacing: 16) {
-          Button {
-            // TODO: 약관 동의 이벤트
-          } label: {
-            HStack {
-              CofficeAsset.Asset.checkboxCircleLine24px.swiftUIImage
-                .renderingMode(.template)
-                .foregroundColor(CofficeAsset.Colors.grayScale4.swiftUIColor)
-              Text("서비스 이용약관")
-                .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
-                .applyCofficeFont(font: .subtitle1Medium)
-              Text("(필수)")
-                .foregroundColor(CofficeAsset.Colors.secondary1.swiftUIColor)
-                .applyCofficeFont(font: .subtitle1Medium)
-              Spacer()
-            }
-            .frame(height: 32)
-          }
-
-          CofficeAsset.Asset.arrowDropRightLine24px.swiftUIImage
-        }
-        .padding(.bottom, 20)
-
-        HStack(spacing: 16) {
-          Button {
-            // TODO: 약관 동의 이벤트
-          } label: {
-            HStack {
-              CofficeAsset.Asset.checkboxCircleLine24px.swiftUIImage
-                .renderingMode(.template)
-                .foregroundColor(CofficeAsset.Colors.grayScale4.swiftUIColor)
-              Text("서비스 이용약관")
-                .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
-                .applyCofficeFont(font: .subtitle1Medium)
-              Text("(필수)")
-                .foregroundColor(CofficeAsset.Colors.secondary1.swiftUIColor)
-                .applyCofficeFont(font: .subtitle1Medium)
-              Spacer()
-            }
-            .frame(height: 32)
-          }
-
-          CofficeAsset.Asset.arrowDropRightLine24px.swiftUIImage
-        }
-        .padding(.bottom, 20)
 
         Button {
-
+          viewStore.send(.delegate(.confirmButtonTapped))
         } label: {
           Text("확인")
             .foregroundColor(CofficeAsset.Colors.grayScale1.swiftUIColor)
@@ -125,12 +83,13 @@ struct LoginServiceTermsBottomSheetView: View {
             .frame(maxWidth: .infinity, alignment: .center)
             .frame(height: 44)
             .background(
-              CofficeAsset.Colors.grayScale5.swiftUIColor
+              viewStore.confirmButtonBackgroundColor.swiftUIColor
                 .frame(height: 44)
                 .cornerRadius(4, corners: .allCorners)
             )
         }
         .padding(.vertical, 20)
+        .disabled(viewStore.isWholeTermsAgreed.isFalse)
       }
       .padding(.horizontal, 20)
       .padding(.bottom, UIApplication.keyWindow?.safeAreaInsets.bottom ?? 0)

--- a/Projects/Coffice/Sources/App/Login/LoginServiceTermsBottomSheetView.swift
+++ b/Projects/Coffice/Sources/App/Login/LoginServiceTermsBottomSheetView.swift
@@ -1,0 +1,157 @@
+//
+//  LoginServiceTermsBottomSheetView.swift
+//  coffice
+//
+//  Created by Min Min on 2023/07/20.
+//  Copyright (c) 2023 kr.co.yapp. All rights reserved.
+//
+
+import ComposableArchitecture
+import SwiftUI
+
+struct LoginServiceTermsBottomSheetView: View {
+  private let store: StoreOf<LoginServiceTermsBottomSheet>
+
+  init(store: StoreOf<LoginServiceTermsBottomSheet>) {
+    self.store = store
+  }
+
+  var body: some View {
+    WithViewStore(store) { viewStore in
+      VStack(spacing: 0) {
+        Text("이용 약관 동의")
+          .foregroundColor(CofficeAsset.Colors.grayScale9.swiftUIColor)
+          .applyCofficeFont(font: .header1)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .frame(height: 32)
+          .padding(.top, 28)
+          .padding(.bottom, 20)
+
+        HStack(spacing: 16) {
+          Button {
+            // TODO: 약관 전체 동의 이벤트
+          } label: {
+            CofficeAsset.Asset.checkboxCircleLine24px.swiftUIImage
+              .renderingMode(.template)
+              .foregroundColor(CofficeAsset.Colors.grayScale4.swiftUIColor)
+          }
+          Text("약관 전체 동의")
+            .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
+            .applyCofficeFont(font: .subtitle1Medium)
+          Spacer()
+        }
+        .frame(height: 32)
+        .padding(.vertical, 20)
+
+        CofficeAsset.Colors.grayScale3.swiftUIColor
+          .frame(height: 1)
+          .padding(.bottom, 20)
+
+        HStack(spacing: 16) {
+          Button {
+            // TODO: 약관 동의 이벤트
+          } label: {
+            HStack {
+              CofficeAsset.Asset.checkboxCircleLine24px.swiftUIImage
+                .renderingMode(.template)
+                .foregroundColor(CofficeAsset.Colors.grayScale4.swiftUIColor)
+              Text("서비스 이용약관")
+                .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
+                .applyCofficeFont(font: .subtitle1Medium)
+              Text("(필수)")
+                .foregroundColor(CofficeAsset.Colors.secondary1.swiftUIColor)
+                .applyCofficeFont(font: .subtitle1Medium)
+              Spacer()
+            }
+            .frame(height: 32)
+          }
+
+          CofficeAsset.Asset.arrowDropRightLine24px.swiftUIImage
+        }
+        .padding(.bottom, 20)
+
+        HStack(spacing: 16) {
+          Button {
+            // TODO: 약관 동의 이벤트
+          } label: {
+            HStack {
+              CofficeAsset.Asset.checkboxCircleLine24px.swiftUIImage
+                .renderingMode(.template)
+                .foregroundColor(CofficeAsset.Colors.grayScale4.swiftUIColor)
+              Text("서비스 이용약관")
+                .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
+                .applyCofficeFont(font: .subtitle1Medium)
+              Text("(필수)")
+                .foregroundColor(CofficeAsset.Colors.secondary1.swiftUIColor)
+                .applyCofficeFont(font: .subtitle1Medium)
+              Spacer()
+            }
+            .frame(height: 32)
+          }
+
+          CofficeAsset.Asset.arrowDropRightLine24px.swiftUIImage
+        }
+        .padding(.bottom, 20)
+
+        HStack(spacing: 16) {
+          Button {
+            // TODO: 약관 동의 이벤트
+          } label: {
+            HStack {
+              CofficeAsset.Asset.checkboxCircleLine24px.swiftUIImage
+                .renderingMode(.template)
+                .foregroundColor(CofficeAsset.Colors.grayScale4.swiftUIColor)
+              Text("서비스 이용약관")
+                .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
+                .applyCofficeFont(font: .subtitle1Medium)
+              Text("(필수)")
+                .foregroundColor(CofficeAsset.Colors.secondary1.swiftUIColor)
+                .applyCofficeFont(font: .subtitle1Medium)
+              Spacer()
+            }
+            .frame(height: 32)
+          }
+
+          CofficeAsset.Asset.arrowDropRightLine24px.swiftUIImage
+        }
+        .padding(.bottom, 20)
+
+        Button {
+
+        } label: {
+          Text("확인")
+            .foregroundColor(CofficeAsset.Colors.grayScale1.swiftUIColor)
+            .applyCofficeFont(font: .button)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .frame(height: 44)
+            .background(
+              CofficeAsset.Colors.grayScale5.swiftUIColor
+                .frame(height: 44)
+                .cornerRadius(4, corners: .allCorners)
+            )
+        }
+        .padding(.vertical, 20)
+      }
+      .padding(.horizontal, 20)
+      .padding(.bottom, UIApplication.keyWindow?.safeAreaInsets.bottom ?? 0)
+      .background(
+        CofficeAsset.Colors.grayScale1.swiftUIColor
+          .cornerRadius(18, corners: [.topLeft, .topRight])
+      )
+      .onAppear {
+        viewStore.send(.onAppear)
+      }
+    }
+  }
+}
+
+struct LoginServiceTermsSheetView_Previews: PreviewProvider {
+  static var previews: some View {
+    LoginServiceTermsBottomSheetView(
+      store: .init(
+        initialState: .initialState,
+        reducer: LoginServiceTermsBottomSheet()
+      )
+    )
+  }
+}

--- a/Projects/Coffice/Sources/App/Login/LoginServiceTermsBottomSheetView.swift
+++ b/Projects/Coffice/Sources/App/Login/LoginServiceTermsBottomSheetView.swift
@@ -68,7 +68,11 @@ struct LoginServiceTermsBottomSheetView: View {
                 .frame(height: 32)
               }
 
-              CofficeAsset.Asset.arrowDropRightLine24px.swiftUIImage
+              Button {
+                viewStore.send(.termsWebMenuButtonTapped(termsType: viewState.type))
+              } label: {
+                CofficeAsset.Asset.arrowDropRightLine24px.swiftUIImage
+              }
             }
             .padding(.bottom, 20)
           }

--- a/Projects/Coffice/Sources/App/Login/LoginServiceTermsSheetCore.swift
+++ b/Projects/Coffice/Sources/App/Login/LoginServiceTermsSheetCore.swift
@@ -1,0 +1,32 @@
+//
+//  LoginServiceTermsBottomSheetCore.swift
+//  coffice
+//
+//  Created by Min Min on 2023/07/20.
+//  Copyright (c) 2023 kr.co.yapp. All rights reserved.
+//
+
+import ComposableArchitecture
+
+struct LoginServiceTermsBottomSheet: ReducerProtocol {
+  struct State: Equatable {
+    static let initialState: State = .init()
+  }
+
+  enum Action: Equatable {
+    case onAppear
+    case dismissView
+  }
+
+  var body: some ReducerProtocolOf<LoginServiceTermsBottomSheet> {
+    Reduce { state, action in
+      switch action {
+      case .onAppear:
+        return .none
+
+      default:
+        return .none
+      }
+    }
+  }
+}

--- a/Projects/Coffice/Sources/App/Login/LoginServiceTermsSheetCore.swift
+++ b/Projects/Coffice/Sources/App/Login/LoginServiceTermsSheetCore.swift
@@ -7,14 +7,85 @@
 //
 
 import ComposableArchitecture
+import Foundation
 
 struct LoginServiceTermsBottomSheet: ReducerProtocol {
+  enum TermsType: Int, CaseIterable {
+    case appService
+    case locationService
+    case privacyPolicy
+  }
+
+  struct TermsOptionButtonViewState: Equatable, Identifiable {
+    let id = UUID()
+    let type: TermsType
+    var isSelected: Bool
+
+    var title: String {
+      switch type {
+      case .appService:
+        return "서비스 이용약관"
+      case .locationService:
+        return "위치기반 서비스 이용약관"
+      case .privacyPolicy:
+        return "개인정보 처리방침"
+      }
+    }
+
+    var index: Int {
+      return type.rawValue
+    }
+
+    var checkboxImage: CofficeImages {
+      isSelected
+      ? CofficeAsset.Asset.checkboxCircleFill24px
+      : CofficeAsset.Asset.checkboxCircleLine24px
+    }
+
+    var checkboxImageColor: CofficeColors {
+      isSelected
+      ? CofficeAsset.Colors.grayScale9
+      : CofficeAsset.Colors.grayScale4
+    }
+  }
+
   struct State: Equatable {
     static let initialState: State = .init()
+    var termsOptionButtonViewStates: [TermsOptionButtonViewState] = TermsType.allCases
+      .map({ TermsOptionButtonViewState(type: $0, isSelected: false) }) {
+        didSet {
+          isWholeTermsAgreed = termsOptionButtonViewStates.allSatisfy(\.isSelected)
+        }
+      }
+    var isWholeTermsAgreed = false
+    var wholeTermsAgreementCheckboxImage: CofficeImages {
+      isWholeTermsAgreed
+      ? CofficeAsset.Asset.checkboxCircleFill24px
+      : CofficeAsset.Asset.checkboxCircleLine24px
+    }
+
+    var wholeTermsAgreementCheckboxColor: CofficeColors {
+      isWholeTermsAgreed
+      ? CofficeAsset.Colors.grayScale9
+      : CofficeAsset.Colors.grayScale4
+    }
+
+    var confirmButtonBackgroundColor: CofficeColors {
+      isWholeTermsAgreed
+      ? CofficeAsset.Colors.grayScale9
+      : CofficeAsset.Colors.grayScale5
+    }
   }
 
   enum Action: Equatable {
     case onAppear
+    case wholeTermsAgreementButtonTapped
+    case termsOptionButtonTapped(viewState: TermsOptionButtonViewState)
+    case delegate(Delegate)
+  }
+
+  enum Delegate: Equatable {
+    case confirmButtonTapped
     case dismissView
   }
 
@@ -22,6 +93,17 @@ struct LoginServiceTermsBottomSheet: ReducerProtocol {
     Reduce { state, action in
       switch action {
       case .onAppear:
+        return .none
+
+      case .wholeTermsAgreementButtonTapped:
+        state.isWholeTermsAgreed.toggle()
+        let isWholeTermsAgreed = state.isWholeTermsAgreed
+        state.termsOptionButtonViewStates = TermsType.allCases
+          .map { TermsOptionButtonViewState(type: $0, isSelected: isWholeTermsAgreed) }
+        return .none
+
+      case .termsOptionButtonTapped(let viewState):
+        state.termsOptionButtonViewStates[viewState.index].isSelected.toggle()
         return .none
 
       default:

--- a/Projects/Coffice/Sources/App/Login/LoginServiceTermsSheetCore.swift
+++ b/Projects/Coffice/Sources/App/Login/LoginServiceTermsSheetCore.swift
@@ -10,6 +10,56 @@ import ComposableArchitecture
 import Foundation
 
 struct LoginServiceTermsBottomSheet: ReducerProtocol {
+  struct State: Equatable {
+    static let initialState: State = .init()
+    var termsOptionButtonViewStates: [TermsOptionButtonViewState] = TermsType.allCases
+      .map({ TermsOptionButtonViewState(type: $0, isSelected: false) }) {
+        didSet {
+          isWholeTermsAgreed = termsOptionButtonViewStates.allSatisfy(\.isSelected)
+        }
+      }
+    var isWholeTermsAgreed = false
+  }
+
+  enum Action: Equatable {
+    case onAppear
+    case wholeTermsAgreementButtonTapped
+    case termsOptionButtonTapped(viewState: TermsOptionButtonViewState)
+    case delegate(Delegate)
+  }
+
+  enum Delegate: Equatable {
+    case confirmButtonTapped
+    case dismissView
+  }
+
+  var body: some ReducerProtocolOf<LoginServiceTermsBottomSheet> {
+    Reduce { state, action in
+      switch action {
+      case .onAppear:
+        return .none
+
+      case .wholeTermsAgreementButtonTapped:
+        state.isWholeTermsAgreed.toggle()
+        let isWholeTermsAgreed = state.isWholeTermsAgreed
+        state.termsOptionButtonViewStates = TermsType.allCases
+          .map { TermsOptionButtonViewState(type: $0, isSelected: isWholeTermsAgreed) }
+        return .none
+
+      case .termsOptionButtonTapped(let viewState):
+        state.termsOptionButtonViewStates[viewState.index].isSelected.toggle()
+        return .none
+
+      default:
+        return .none
+      }
+    }
+  }
+}
+
+// MARK: - Sub Models
+
+extension LoginServiceTermsBottomSheet {
   enum TermsType: Int, CaseIterable {
     case appService
     case locationService
@@ -48,67 +98,26 @@ struct LoginServiceTermsBottomSheet: ReducerProtocol {
       : CofficeAsset.Colors.grayScale4
     }
   }
+}
 
-  struct State: Equatable {
-    static let initialState: State = .init()
-    var termsOptionButtonViewStates: [TermsOptionButtonViewState] = TermsType.allCases
-      .map({ TermsOptionButtonViewState(type: $0, isSelected: false) }) {
-        didSet {
-          isWholeTermsAgreed = termsOptionButtonViewStates.allSatisfy(\.isSelected)
-        }
-      }
-    var isWholeTermsAgreed = false
-    var wholeTermsAgreementCheckboxImage: CofficeImages {
-      isWholeTermsAgreed
-      ? CofficeAsset.Asset.checkboxCircleFill24px
-      : CofficeAsset.Asset.checkboxCircleLine24px
-    }
+// MARK: - Getters
 
-    var wholeTermsAgreementCheckboxColor: CofficeColors {
-      isWholeTermsAgreed
-      ? CofficeAsset.Colors.grayScale9
-      : CofficeAsset.Colors.grayScale4
-    }
-
-    var confirmButtonBackgroundColor: CofficeColors {
-      isWholeTermsAgreed
-      ? CofficeAsset.Colors.grayScale9
-      : CofficeAsset.Colors.grayScale5
-    }
+extension LoginServiceTermsBottomSheet.State {
+  var wholeTermsAgreementCheckboxImage: CofficeImages {
+    isWholeTermsAgreed
+    ? CofficeAsset.Asset.checkboxCircleFill24px
+    : CofficeAsset.Asset.checkboxCircleLine24px
   }
 
-  enum Action: Equatable {
-    case onAppear
-    case wholeTermsAgreementButtonTapped
-    case termsOptionButtonTapped(viewState: TermsOptionButtonViewState)
-    case delegate(Delegate)
+  var wholeTermsAgreementCheckboxColor: CofficeColors {
+    isWholeTermsAgreed
+    ? CofficeAsset.Colors.grayScale9
+    : CofficeAsset.Colors.grayScale4
   }
 
-  enum Delegate: Equatable {
-    case confirmButtonTapped
-    case dismissView
-  }
-
-  var body: some ReducerProtocolOf<LoginServiceTermsBottomSheet> {
-    Reduce { state, action in
-      switch action {
-      case .onAppear:
-        return .none
-
-      case .wholeTermsAgreementButtonTapped:
-        state.isWholeTermsAgreed.toggle()
-        let isWholeTermsAgreed = state.isWholeTermsAgreed
-        state.termsOptionButtonViewStates = TermsType.allCases
-          .map { TermsOptionButtonViewState(type: $0, isSelected: isWholeTermsAgreed) }
-        return .none
-
-      case .termsOptionButtonTapped(let viewState):
-        state.termsOptionButtonViewStates[viewState.index].isSelected.toggle()
-        return .none
-
-      default:
-        return .none
-      }
-    }
+  var confirmButtonBackgroundColor: CofficeColors {
+    isWholeTermsAgreed
+    ? CofficeAsset.Colors.grayScale9
+    : CofficeAsset.Colors.grayScale5
   }
 }

--- a/Projects/Coffice/Sources/App/Login/LoginServiceTermsSheetCore.swift
+++ b/Projects/Coffice/Sources/App/Login/LoginServiceTermsSheetCore.swift
@@ -25,6 +25,7 @@ struct LoginServiceTermsBottomSheet: ReducerProtocol {
     case onAppear
     case wholeTermsAgreementButtonTapped
     case termsOptionButtonTapped(viewState: TermsOptionButtonViewState)
+    case termsWebMenuButtonTapped(termsType: TermsType)
     case delegate(Delegate)
   }
 
@@ -49,6 +50,17 @@ struct LoginServiceTermsBottomSheet: ReducerProtocol {
       case .termsOptionButtonTapped(let viewState):
         state.termsOptionButtonViewStates[viewState.index].isSelected.toggle()
         return .none
+
+      case .termsWebMenuButtonTapped(let termsType):
+        // TODO: 약관동의 웹뷰 표출 필요
+        switch termsType {
+        case .appService:
+          return .none
+        case .locationService:
+          return .none
+        case .privacyPolicy:
+          return .none
+        }
 
       default:
         return .none

--- a/Projects/Coffice/Sources/App/Login/LoginView.swift
+++ b/Projects/Coffice/Sources/App/Login/LoginView.swift
@@ -75,6 +75,18 @@ struct LoginView: View {
         Spacer()
       }
       .padding(20)
+      .popup(
+        item: viewStore.binding(\.$loginServiceTermsBottomSheetState),
+        itemView: { viewState in
+          LoginServiceTermsBottomSheetView(
+            store: store.scope(
+              state: { _ in viewState },
+              action: Login.Action.loginServiceTermsBottomSheetAction
+            )
+          )
+        },
+        customize: BottomSheetContent.customize
+      )
     }
   }
 }


### PR DESCRIPTION
## ☕️ PR 요약
- 로그인 이용약관 바텀 시트뷰 UI를 구성 후, 로그인 flow와 연결했습니다.
- 실기기에서 약관 동의 후 카카오, 애플로그인 flow 정상 동작 확인했습니다.
- todo
  - 이용약관 시트에서 약관동의 웹뷰 표출로직 구현이 필요합니다.


## 📸 ScreenShot
- 예시 영상, 시뮬레이터 기준 영상이라 약관 동의 이후 실제 로그인 플로우는 나오지 않습니다. (시뮬에서 애플로그인은 약관동의 표출로직도 못감)
- 테스트 하신다면, 실기기로 확인 부탁드립니다. 🙏🏻

<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/15d10a38-78c2-4a20-bb77-973fe44854a2" width="200">




##### ✅ PR check list(PR 요청시 확인후 삭제해주세요)
- 약관 동의 후 카카오, 애플로그인 flow가 동작 여부 확인
  - 애플로그인은 약관 동의 바텀 시트뷰 표출 전 일부 로그인 관련 플로우가 존재, 이후 바텀 시트뷰가 표출 됨

```
- commit message가 적절한지 확인해주세요.
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```



#### Linked Issue

related #193 
