### PR TITLE
Feature/#201 login terms of use modal view

### DIFF
--- a/Projects/Coffice/Sources/App/CommonComponents/CommonWebView.swift
+++ b/Projects/Coffice/Sources/App/CommonComponents/CommonWebView.swift
@@ -30,6 +30,7 @@ struct CommonWebView: UIViewRepresentable {
 struct CommonWebReducer: ReducerProtocol {
   struct State: Equatable {
     let urlString: String
+    var transitionType: TransitionType = .none
   }
 
   enum Action: Equatable {
@@ -44,6 +45,37 @@ struct CommonWebReducer: ReducerProtocol {
         else { return .none }
         webView.load(URLRequest(url: webUrl))
         return .none
+      }
+    }
+  }
+}
+
+extension CommonWebReducer {
+  enum TransitionType: Equatable {
+    case privacyPolicy
+    case appServiceTerms
+    case locationServiceTerms
+    case none
+
+    var title: String {
+      switch self {
+      case .privacyPolicy: return "개인정보 처리방침"
+      case .locationServiceTerms: return "위치서비스 약관"
+      case .appServiceTerms: return "서비스 이용약관"
+      default: return ""
+      }
+    }
+
+    var urlString: String {
+      switch self {
+      case .privacyPolicy:
+        return "https://traveling-jade-4ad.notion.site/74a66cfd0dc34c17b0f2f8da4f1cd1bb"
+      case .appServiceTerms:
+        return "https://traveling-jade-4ad.notion.site/0b8d9c87d5be459c97860ddb4bffaa31"
+      case .locationServiceTerms:
+        return "https://traveling-jade-4ad.notion.site/f946b1a337704f108f11d3c6333569d8"
+      default:
+        return ""
       }
     }
   }

--- a/Projects/Coffice/Sources/App/CommonComponents/CommonWebView.swift
+++ b/Projects/Coffice/Sources/App/CommonComponents/CommonWebView.swift
@@ -28,9 +28,9 @@ struct CommonWebView: UIViewRepresentable {
 }
 
 struct CommonWebReducer: ReducerProtocol {
-  struct State: Equatable {
+  struct State: Equatable, Identifiable {
+    let id = UUID()
     let urlString: String
-    var transitionType: TransitionType = .none
   }
 
   enum Action: Equatable {
@@ -45,37 +45,6 @@ struct CommonWebReducer: ReducerProtocol {
         else { return .none }
         webView.load(URLRequest(url: webUrl))
         return .none
-      }
-    }
-  }
-}
-
-extension CommonWebReducer {
-  enum TransitionType: Equatable {
-    case privacyPolicy
-    case appServiceTerms
-    case locationServiceTerms
-    case none
-
-    var title: String {
-      switch self {
-      case .privacyPolicy: return "개인정보 처리방침"
-      case .locationServiceTerms: return "위치서비스 약관"
-      case .appServiceTerms: return "서비스 이용약관"
-      default: return ""
-      }
-    }
-
-    var urlString: String {
-      switch self {
-      case .privacyPolicy:
-        return "https://traveling-jade-4ad.notion.site/74a66cfd0dc34c17b0f2f8da4f1cd1bb"
-      case .appServiceTerms:
-        return "https://traveling-jade-4ad.notion.site/0b8d9c87d5be459c97860ddb4bffaa31"
-      case .locationServiceTerms:
-        return "https://traveling-jade-4ad.notion.site/f946b1a337704f108f11d3c6333569d8"
-      default:
-        return ""
       }
     }
   }

--- a/Projects/Coffice/Sources/App/Login/LoginServiceTermsBottomSheetView.swift
+++ b/Projects/Coffice/Sources/App/Login/LoginServiceTermsBottomSheetView.swift
@@ -69,7 +69,7 @@ struct LoginServiceTermsBottomSheetView: View {
               }
 
               Button {
-                viewStore.send(.termsWebMenuButtonTapped(termsType: viewState.type))
+                viewStore.send(.termsWebMenuButtonTapped(viewState: viewState))
               } label: {
                 CofficeAsset.Asset.arrowDropRightLine24px.swiftUIImage
               }
@@ -104,6 +104,34 @@ struct LoginServiceTermsBottomSheetView: View {
       .onAppear {
         viewStore.send(.onAppear)
       }
+      .sheet(
+        item: viewStore.$webViewState,
+        content: { viewState in
+          VStack(spacing: 0) {
+            CommonWebView(
+              store: store.scope(
+                state: { _ in viewState },
+                action: LoginServiceTermsBottomSheet.Action.commonWebReducerAction
+              )
+            )
+          }
+          .customNavigationBar(
+            centerView: {
+              Text(viewStore.webViewTitle)
+            },
+            leftView: {
+              EmptyView()
+            },
+            rightView: {
+              Button {
+                viewStore.send(.dismissWebView)
+              } label: {
+                CofficeAsset.Asset.close40px.swiftUIImage
+              }
+            }
+          )
+        }
+      )
     }
   }
 }

--- a/Projects/Coffice/Sources/App/Login/LoginServiceTermsSheetCore.swift
+++ b/Projects/Coffice/Sources/App/Login/LoginServiceTermsSheetCore.swift
@@ -19,6 +19,7 @@ struct LoginServiceTermsBottomSheet: ReducerProtocol {
         }
       }
     var isWholeTermsAgreed = false
+    @BindingState var commonWebReducerState: CommonWebReducer.State?
   }
 
   enum Action: Equatable {
@@ -27,6 +28,7 @@ struct LoginServiceTermsBottomSheet: ReducerProtocol {
     case termsOptionButtonTapped(viewState: TermsOptionButtonViewState)
     case termsWebMenuButtonTapped(termsType: TermsType)
     case delegate(Delegate)
+    case commonWebReducerAction(CommonWebReducer.Action)
   }
 
   enum Delegate: Equatable {
@@ -55,16 +57,37 @@ struct LoginServiceTermsBottomSheet: ReducerProtocol {
         // TODO: 약관동의 웹뷰 표출 필요
         switch termsType {
         case .appService:
+          state.commonWebReducerState = .init(
+            urlString: CommonWebReducer.TransitionType.appServiceTerms.urlString,
+            transitionType: .privacyPolicy
+          )
           return .none
+
         case .locationService:
+          state.commonWebReducerState = .init(
+            urlString: CommonWebReducer.TransitionType.locationServiceTerms.urlString,
+            transitionType: .locationServiceTerms
+          )
           return .none
+
         case .privacyPolicy:
+          state.commonWebReducerState = .init(
+            urlString: CommonWebReducer.TransitionType.privacyPolicy.urlString,
+            transitionType: .privacyPolicy
+          )
           return .none
         }
 
       default:
         return .none
       }
+    }
+    // TODO: CommonWebReducer액션 감지, dismiss시, State nil 등등..
+    .ifLet(
+      \.commonWebReducerState,
+       action: /Action.commonWebReducerAction
+    ) {
+      CommonWebReducer()
     }
   }
 }


### PR DESCRIPTION
## ☕️ PR 요약
- 로그인 약관동의 바텀 시트 뷰를 통한 약관 웹뷰 플로우를 구성했습니다.
- todo:
  - 약관동의 웹뷰 안에서 main thread 에서 동작하지 않는다는 에러 로그가 발생해서 추가 수정이 필요합니다.
  - 추후 옵션에따라 네비게이션, 모달 방식 등 옵션에 따라 동작할 수 있도록 웹뷰를 개선해보면 어떨까 하는 생각이 들었습니다.


## 📸 ScreenShot
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/877f85a1-cff1-4829-85d7-f139bc51062c" width="200">



##### ✅ PR check list(PR 요청시 확인후 삭제해주세요)

```
- commit message가 적절한지 확인해주세요.
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```



#### Linked Issue

close #201 
