### PR TITLE
[Fix] Color Asset IPhone -> universal로 수정

### DIFF
--- a/Projects/Coffice/Resources/Colors.xcassets/grayScale1.colorset/Contents.json
+++ b/Projects/Coffice/Resources/Colors.xcassets/grayScale1.colorset/Contents.json
@@ -10,7 +10,7 @@
           "red" : "1.000"
         }
       },
-      "idiom" : "iphone"
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Projects/Coffice/Resources/Colors.xcassets/grayScale10.colorset/Contents.json
+++ b/Projects/Coffice/Resources/Colors.xcassets/grayScale10.colorset/Contents.json
@@ -10,7 +10,7 @@
           "red" : "0x00"
         }
       },
-      "idiom" : "iphone"
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Projects/Coffice/Resources/Colors.xcassets/grayScale2.colorset/Contents.json
+++ b/Projects/Coffice/Resources/Colors.xcassets/grayScale2.colorset/Contents.json
@@ -10,7 +10,7 @@
           "red" : "0.961"
         }
       },
-      "idiom" : "iphone"
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Projects/Coffice/Resources/Colors.xcassets/grayScale3.colorset/Contents.json
+++ b/Projects/Coffice/Resources/Colors.xcassets/grayScale3.colorset/Contents.json
@@ -10,7 +10,7 @@
           "red" : "0.933"
         }
       },
-      "idiom" : "iphone"
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Projects/Coffice/Resources/Colors.xcassets/grayScale4.colorset/Contents.json
+++ b/Projects/Coffice/Resources/Colors.xcassets/grayScale4.colorset/Contents.json
@@ -10,7 +10,7 @@
           "red" : "0.875"
         }
       },
-      "idiom" : "iphone"
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Projects/Coffice/Resources/Colors.xcassets/grayScale5.colorset/Contents.json
+++ b/Projects/Coffice/Resources/Colors.xcassets/grayScale5.colorset/Contents.json
@@ -10,7 +10,7 @@
           "red" : "0.765"
         }
       },
-      "idiom" : "iphone"
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Projects/Coffice/Resources/Colors.xcassets/grayScale6.colorset/Contents.json
+++ b/Projects/Coffice/Resources/Colors.xcassets/grayScale6.colorset/Contents.json
@@ -10,7 +10,7 @@
           "red" : "0.706"
         }
       },
-      "idiom" : "iphone"
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Projects/Coffice/Resources/Colors.xcassets/grayScale7.colorset/Contents.json
+++ b/Projects/Coffice/Resources/Colors.xcassets/grayScale7.colorset/Contents.json
@@ -10,7 +10,7 @@
           "red" : "0.467"
         }
       },
-      "idiom" : "iphone"
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Projects/Coffice/Resources/Colors.xcassets/grayScale8.colorset/Contents.json
+++ b/Projects/Coffice/Resources/Colors.xcassets/grayScale8.colorset/Contents.json
@@ -10,7 +10,7 @@
           "red" : "0x46"
         }
       },
-      "idiom" : "iphone"
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Projects/Coffice/Resources/Colors.xcassets/grayScale9.colorset/Contents.json
+++ b/Projects/Coffice/Resources/Colors.xcassets/grayScale9.colorset/Contents.json
@@ -10,7 +10,7 @@
           "red" : "0x20"
         }
       },
-      "idiom" : "iphone"
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Projects/Coffice/Resources/Colors.xcassets/kakao.colorset/Contents.json
+++ b/Projects/Coffice/Resources/Colors.xcassets/kakao.colorset/Contents.json
@@ -10,7 +10,7 @@
           "red" : "0xFE"
         }
       },
-      "idiom" : "iphone"
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Projects/Coffice/Resources/Colors.xcassets/red.colorset/Contents.json
+++ b/Projects/Coffice/Resources/Colors.xcassets/red.colorset/Contents.json
@@ -10,7 +10,7 @@
           "red" : "0xEE"
         }
       },
-      "idiom" : "iphone"
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Projects/Coffice/Resources/Colors.xcassets/secondary0.colorset/Contents.json
+++ b/Projects/Coffice/Resources/Colors.xcassets/secondary0.colorset/Contents.json
@@ -10,7 +10,7 @@
           "red" : "0x6B"
         }
       },
-      "idiom" : "iphone"
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Projects/Coffice/Resources/Colors.xcassets/secondary1.colorset/Contents.json
+++ b/Projects/Coffice/Resources/Colors.xcassets/secondary1.colorset/Contents.json
@@ -10,7 +10,7 @@
           "red" : "0.576"
         }
       },
-      "idiom" : "iphone"
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Projects/Coffice/Resources/Colors.xcassets/secondary2.colorset/Contents.json
+++ b/Projects/Coffice/Resources/Colors.xcassets/secondary2.colorset/Contents.json
@@ -10,7 +10,7 @@
           "red" : "0.725"
         }
       },
-      "idiom" : "iphone"
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Projects/Coffice/Resources/Colors.xcassets/secondary3.colorset/Contents.json
+++ b/Projects/Coffice/Resources/Colors.xcassets/secondary3.colorset/Contents.json
@@ -10,7 +10,7 @@
           "red" : "0.816"
         }
       },
-      "idiom" : "iphone"
+      "idiom" : "universal"
     }
   ],
   "info" : {


### PR DESCRIPTION
## ☕️ PR 요약

Color Asset universal로 수정 ipad 뷰 깨짐 현상 해결


## 📸 ScreenShot
|          AS-IS          |          TO-BE          |
| :---------------------: | :---------------------: |
|<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/108966759/e7a4d82b-223d-4921-b143-6dd13f551afe" width="200"> |  <img src="https://github.com/YAPP-Github/Coffice-iOS/assets/108966759/c3d53761-aa77-43c6-a348-aee38a373329" width="200">|






#### Linked Issue

close #205 
