### PR TITLE
Feature/#214 extend main searchbar touch area

### DIFF
--- a/Projects/Coffice/Sources/App/Main/Search/CafeMapView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeMapView.swift
@@ -175,3 +175,14 @@ extension CafeMapView {
     .padding(.top, 8)
   }
 }
+
+struct CafeMapView_Previews: PreviewProvider {
+  static var previews: some View {
+    CafeMapView(
+      store: .init(
+        initialState: .init(),
+        reducer: CafeMapCore()
+      )
+    )
+  }
+}

--- a/Projects/Coffice/Sources/App/Main/Search/CafeMapView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeMapView.swift
@@ -47,6 +47,7 @@ struct CafeMapView: View {
 
           VStack(alignment: .center, spacing: 0) {
             headerView
+              .contentShape(Rectangle())
               .onTapGesture { viewStore.send(.updateDisplayType(.searchView)) }
               .background(CofficeAsset.Colors.grayScale1.swiftUIColor)
               .padding(.bottom, 20)


### PR DESCRIPTION
## ☕️ PR 요약
- 검색 메인, 상단 검색바 우측 여백이 터치영역으로 적용되지 않는 문제 수정

## 📸 ScreenShot
- "지하철, 카페 이름으로 검색" 우측 여백도 터치영역으로 설정
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/231673f2-f550-4eb5-bae7-afc346ecf2c0" width="200">



##### ✅ PR check list(PR 요청시 확인후 삭제해주세요)

```
- commit message가 적절한지 확인해주세요.
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```



#### Linked Issue

close #214 
