### PR TITLE
[Feat] #221 #186 카페 상세 시간/푸드/음료 정보 표시방식 수정 (#213 선행 merge 필요)

### DIFF
--- a/Projects/Coffice/Sources/App/Entities/ResponseValue/GetReviewResponse.swift
+++ b/Projects/Coffice/Sources/App/Entities/ResponseValue/GetReviewResponse.swift
@@ -65,11 +65,8 @@ struct ReviewResponse: Equatable {
     }
 
     self.content = content
-
-    let dateFormatter = DateFormatter()
-    dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS+09:00"
-    dateFormatter.locale = Locale(identifier: "ko_KR")
-    createdDate = dateFormatter.date(from: createdAt)
-    updatedDate = dateFormatter.date(from: updatedAt)
+    let rawDateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS+09:00"
+    createdDate = createdAt.utcDate(format: rawDateFormat)
+    updatedDate = updatedAt.utcDate(format: rawDateFormat)
   }
 }

--- a/Projects/Coffice/Sources/App/Extensions/String+Extensions.swift
+++ b/Projects/Coffice/Sources/App/Extensions/String+Extensions.swift
@@ -19,4 +19,15 @@ extension String {
     attributedString[range].font = .custom(CofficeFont.subtitleSemiBold.name, size: 16)
     return attributedString
   }
+
+  func utcDate(format: String) -> Date? {
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = format
+    dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
+
+    guard let utcDate = dateFormatter.date(from: self)
+    else { return nil }
+
+    return utcDate
+  }
 }

--- a/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailCore.swift
@@ -53,6 +53,15 @@ struct CafeDetail: ReducerProtocol {
       }
     }
 
+    var updatedDate: Date?
+    var updatedDateDescription: String {
+      guard let updatedDate else { return "-" }
+      let dateFormatter = DateFormatter()
+      dateFormatter.dateFormat = "M월 dd일 hh:mm 기준"
+      let date = Date()
+      return dateFormatter.string(from: date)
+    }
+
     let imagePageViewHeight: CGFloat = 346.0
     let homeMenuViewHeight: CGFloat = 100.0
     var needToPresentRunningTimeDetailInfo = false
@@ -113,6 +122,7 @@ struct CafeDetail: ReducerProtocol {
     case reviewReportSheetButtonTapped
     case reviewReportButtonTapped(viewState: State.UserReviewCellViewState)
     case resetSelectedReviewModifySheetActionType
+    case updateUpdatedDate
   }
 
   @Dependency(\.accountClient) private var accountClient
@@ -251,7 +261,7 @@ struct CafeDetail: ReducerProtocol {
         state.subSecondaryInfoViewStates = CafeDetail.State.SubSecondaryInfoType.allCases
           .map { CafeDetail.State.SubSecondaryInfoViewState(cafe: cafe, type: $0) }
 
-        return .none
+        return EffectTask(value: .updateUpdatedDate)
 
       case .subMenuTapped(let menuType):
         state.selectedSubMenuType = menuType
@@ -430,6 +440,10 @@ struct CafeDetail: ReducerProtocol {
 
       case .resetSelectedReviewModifySheetActionType:
         state.selectedReviewSheetActionType = .none
+        return .none
+
+      case .updateUpdatedDate:
+        state.updatedDate = Date()
         return .none
 
       default:

--- a/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailCore.swift
@@ -121,7 +121,7 @@ struct CafeDetail: ReducerProtocol {
     case reviewReportSheetButtonTapped
     case reviewReportButtonTapped(viewState: State.UserReviewCellViewState)
     case resetSelectedReviewModifySheetActionType
-    case updateUpdatedDate
+    case updateLastModifiedDate
   }
 
   @Dependency(\.accountClient) private var accountClient
@@ -260,7 +260,7 @@ struct CafeDetail: ReducerProtocol {
         state.subSecondaryInfoViewStates = CafeDetail.State.SubSecondaryInfoType.allCases
           .map { CafeDetail.State.SubSecondaryInfoViewState(cafe: cafe, type: $0) }
 
-        return EffectTask(value: .updateUpdatedDate)
+        return EffectTask(value: .updateLastModifiedDate)
 
       case .subMenuTapped(let menuType):
         state.selectedSubMenuType = menuType
@@ -441,7 +441,7 @@ struct CafeDetail: ReducerProtocol {
         state.selectedReviewSheetActionType = .none
         return .none
 
-      case .updateUpdatedDate:
+      case .updateLastModifiedDate:
         state.updatedDate = Date()
         return .none
 

--- a/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailCore.swift
@@ -58,8 +58,7 @@ struct CafeDetail: ReducerProtocol {
       guard let updatedDate else { return "-" }
       let dateFormatter = DateFormatter()
       dateFormatter.dateFormat = "M월 dd일 hh:mm 기준"
-      let date = Date()
-      return dateFormatter.string(from: date)
+      return dateFormatter.string(from: updatedDate)
     }
 
     let imagePageViewHeight: CGFloat = 346.0
@@ -611,11 +610,17 @@ extension CafeDetail.State {
 
       switch type {
       case .food:
-        description = cafe.foodTypes?.map { $0.text }.joined(separator: "/") ?? "-"
+        let foodTypeTexts = cafe.foodTypes?.map(\.text) ?? []
+        description = foodTypeTexts.isNotEmpty
+        ? foodTypeTexts.joined(separator: "/")
+        : "-"
       case .toilet:
         description = "-" // FIXME: 서버에서 안내려오는중 (화장실 정보)
       case .beverage:
-        description = cafe.drinkTypes?.map { $0.text }.joined(separator: "/") ?? "-"
+        let drinkTypeTexts = cafe.drinkTypes?.map(\.text) ?? []
+        description = drinkTypeTexts.isNotEmpty
+        ? drinkTypeTexts.joined(separator: "/")
+        : "-"
       case .price:
         description = "-" // FIXME: 서버에서 안내려오는중 (가격 정보)
       case .congestion:

--- a/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailSubInfoView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailSubInfoView.swift
@@ -97,11 +97,11 @@ extension CafeDetailSubInfoView {
   }
 
   private var cafeSecondaryInfoView: some View {
-    WithViewStore(store, observe: \.subSecondaryInfoViewStates) { viewStore in
+    WithViewStore(store) { viewStore in
       VStack(alignment: .leading, spacing: 0) {
         HStack {
           VStack(spacing: 0) {
-            ForEach(viewStore.state) { viewState in
+            ForEach(viewStore.subSecondaryInfoViewStates) { viewState in
               Text(viewState.title)
                 .foregroundColor(CofficeAsset.Colors.grayScale9.swiftUIColor)
                 .applyCofficeFont(font: .button)
@@ -112,7 +112,7 @@ extension CafeDetailSubInfoView {
           }
 
           VStack(alignment: .leading, spacing: 0) {
-            ForEach(viewStore.state) { viewState in
+            ForEach(viewStore.subSecondaryInfoViewStates) { viewState in
               HStack {
                 Text(viewState.description)
                   .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
@@ -127,7 +127,7 @@ extension CafeDetailSubInfoView {
 
                   Spacer()
 
-                  Text("6월 22일 16:00 기준")
+                  Text(viewStore.updatedDateDescription)
                     .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
                     .applyCofficeFont(font: .body2Medium)
                     .frame(alignment: .trailing)


### PR DESCRIPTION
## ☕️ PR 요약
- [x] 카페 상세 업데이트 시간(테스트데이터가 표시되고 있었음) 정상적으로 나오도록 수정
- [x] 리뷰 작성 시간 정보(KST로 나오고 있지 않았음) 정상적으로 나오도록 수정
- [x] 푸드, 음료 정보도 없는 경우 "-" 나오도록 수정

## 📸 ScreenShot
- 아래 영상에서 리뷰작성 시간정보도 정확한 시간 정보가 나옴을 설명하기 위해 임의로 dateFormat을 시/분/초가 함께 나오게 했습니다. (PR에는 올리지 않았어요)
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/0fe35b4a-0f7e-4c68-b45d-6662ca5dc297" width="200">



##### ✅ PR check list(PR 요청시 확인후 삭제해주세요)

```
- commit message가 적절한지 확인해주세요.
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```



#### Linked Issue

related #186 
close #221 
