### PR TITLE
[Fix] #220 최근 검색어 목록 및 검색키워드 입력 시, 표출되는 지하철, 카페 셀 터치 영역 수정

### DIFF
--- a/Projects/Coffice/Sources/App/Main/Search/CafeSearch/CafeSearchView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeSearch/CafeSearchView.swift
@@ -105,6 +105,7 @@ extension CafeSearchView {
                 waypoint: waypoint,
                 waypointName: waypoint.name.changeMatchTextColor(matchText: viewStore.searchText)
               )
+              .contentShape(Rectangle())
               .onTapGesture { viewStore.send(.waypointCellTapped(waypoint: waypoint)) }
             }
             ForEach(viewStore.cafes, id: \.self) { place in
@@ -112,6 +113,7 @@ extension CafeSearchView {
                 place: place,
                 placeName: place.name.changeMatchTextColor(matchText: viewStore.searchText)
               )
+              .contentShape(Rectangle())
               .onTapGesture { viewStore.send(.placeCellTapped(place: place)) }
             }
           }
@@ -160,6 +162,7 @@ extension CafeSearchView {
           VStack(spacing: 0) {
             ForEach(viewStore.recentSearchWordList, id: \.searchWordId) { searchWord in
               listCell(searchWord.text, searchWord.searchWordId)
+                .contentShape(Rectangle())
                 .onTapGesture { viewStore.send(.recentSearchWordCellTapped(recentWord: searchWord.text)) }
             }
           }


### PR DESCRIPTION
## ☕️ PR 요약

최근 검색어, 검색어 목록의 여백 부분이 터치영역으로 적용되지 않는 문제
 - 최근 검색어 목록 터치 영역을 수정하였습니다
 - 검색 키워드 입력 시, 표출되는 역(강남역..), 카페 터치 영역을 수정하였습니다.



## 📸 ScreenShot

<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/108966759/512188a8-1dcc-4ed2-94bd-37cd795b4430" width="200"> <img src="https://github.com/YAPP-Github/Coffice-iOS/assets/108966759/c3e0d7fe-0b94-447f-9564-59567a2ed6a7" width="200">


#### Linked Issue

close #220 
