### PR TITLE
[Feat]/#236 검색어 입력 시, 표출되는 지하철 역 목록과 카페 목록 사이의 회색 가로선 부재(+ 검색 텍스트 필드 폰트 수정)

### DIFF
--- a/Projects/Coffice/Sources/App/Main/Search/CafeSearch/CafeSearchListView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeSearch/CafeSearchListView.swift
@@ -80,6 +80,8 @@ extension CafeSearchListView {
         .padding(.trailing, 12)
 
         Text(viewStore.title)
+          .applyCofficeFont(font: .subtitle1Medium)
+          .foregroundColor(CofficeAsset.Colors.grayScale9.swiftUIColor)
           .frame(maxWidth: .infinity, alignment: .leading)
           .contentShape(Rectangle())
           .onTapGesture { viewStore.send(.titleLabelTapped) }

--- a/Projects/Coffice/Sources/App/Main/Search/CafeSearch/CafeSearchView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeSearch/CafeSearchView.swift
@@ -21,9 +21,10 @@ struct CafeSearchView: View {
     WithViewStore(store) { viewStore in
       VStack(spacing: 0) {
         cafeSearchHeaderView
-        Divider()
-          .frame(minHeight: 2)
-          .background(CofficeAsset.Colors.grayScale2.swiftUIColor)
+          .background(alignment: .bottom) {
+            CofficeAsset.Colors.grayScale2.swiftUIColor
+              .frame(height: 2)
+          }
         cafeSearchBodyView
       }
       .onAppear {
@@ -111,9 +112,8 @@ extension CafeSearchView {
             }
           }
           .background(alignment: .bottom) {
-            Divider()
-              .frame(minHeight: 2)
-              .background(CofficeAsset.Colors.grayScale2.swiftUIColor)
+            CofficeAsset.Colors.grayScale2.swiftUIColor
+              .frame(height: 2)
           }
           ForEach(viewStore.cafes, id: \.self) { place in
             PlaceCellView(

--- a/Projects/Coffice/Sources/App/Main/Search/CafeSearch/CafeSearchView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeSearch/CafeSearchView.swift
@@ -102,7 +102,7 @@ extension CafeSearchView {
       ScrollView {
         VStack(spacing: 0) {
           VStack(spacing: 0) {
-            ForEach(viewStore.waypoints, id: \.self) { waypoint in
+            ForEach(viewStore.waypoints) { waypoint in
               WaypointCellView(
                 waypoint: waypoint,
                 waypointName: waypoint.name.changeMatchTextColor(matchText: viewStore.searchText)
@@ -115,7 +115,7 @@ extension CafeSearchView {
             CofficeAsset.Colors.grayScale2.swiftUIColor
               .frame(height: 2)
           }
-          ForEach(viewStore.cafes, id: \.self) { place in
+          ForEach(viewStore.cafes) { place in
             PlaceCellView(
               place: place,
               placeName: place.name.changeMatchTextColor(matchText: viewStore.searchText)

--- a/Projects/Coffice/Sources/App/Main/Search/CafeSearch/CafeSearchView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeSearch/CafeSearchView.swift
@@ -98,7 +98,8 @@ extension CafeSearchView {
 
   var searchResultListView: some View {
     WithViewStore(store) { viewStore in
-        ScrollView {
+      ScrollView {
+        VStack(spacing: 0) {
           VStack(spacing: 0) {
             ForEach(viewStore.waypoints, id: \.self) { waypoint in
               WaypointCellView(
@@ -108,17 +109,22 @@ extension CafeSearchView {
               .contentShape(Rectangle())
               .onTapGesture { viewStore.send(.waypointCellTapped(waypoint: waypoint)) }
             }
-            ForEach(viewStore.cafes, id: \.self) { place in
-              PlaceCellView(
-                place: place,
-                placeName: place.name.changeMatchTextColor(matchText: viewStore.searchText)
-              )
-              .contentShape(Rectangle())
-              .onTapGesture { viewStore.send(.placeCellTapped(place: place)) }
-            }
           }
-          .padding(.bottom, TabBarSizePreferenceKey.defaultValue.height)
+          .background(alignment: .bottom) {
+            Divider()
+              .frame(minHeight: 2)
+              .background(CofficeAsset.Colors.grayScale2.swiftUIColor)
+          }
+          ForEach(viewStore.cafes, id: \.self) { place in
+            PlaceCellView(
+              place: place,
+              placeName: place.name.changeMatchTextColor(matchText: viewStore.searchText)
+            )
+            .onTapGesture { viewStore.send(.placeCellTapped(place: place)) }
+          }
         }
+        .padding(.bottom, TabBarSizePreferenceKey.defaultValue.height)
+      }
     }
   }
 


### PR DESCRIPTION
## ☕️ PR 요약

- 검색어 입력 시, 표출되는 지하철 역 목록과 카페 목록 사이의 회색 가로선 부재
- 텍스트 필드에 쓰여진 텍스트 타이포가 다름. (subtitle_md)



## 📸 ScreenShot

<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/108966759/15146711-4459-43f1-92df-46d4f9d4bd01" width="200"> <img src="https://github.com/YAPP-Github/Coffice-iOS/assets/108966759/934ffc47-979c-4297-9828-e6548071a49d" width="200">


#### Linked Issue


close #236 
