### PR TITLE
[Fix] #238 네비게이션 전환 후, 좌측 swipe 시 pop이 되지 않는 문제 수정

### DIFF
--- a/Projects/Coffice/Sources/App/Extensions/UINavigationController+Extensions.swift
+++ b/Projects/Coffice/Sources/App/Extensions/UINavigationController+Extensions.swift
@@ -1,0 +1,20 @@
+//
+//  UINavigationController+Extensions.swift
+//  coffice
+//
+//  Created by Min Min on 2023/07/25.
+//  Copyright © 2023 kr.co.yapp. All rights reserved.
+//
+
+import UIKit
+
+extension UINavigationController: UIGestureRecognizerDelegate {
+  override public func viewDidLoad() {
+    super.viewDidLoad()
+    interactivePopGestureRecognizer?.delegate = self
+  }
+
+  public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+    return viewControllers.count > 1
+  }
+}


### PR DESCRIPTION
## ☕️ PR 요약

해당 pr에서 작업한 내역을 적어주세요.
- 네비게이션 전환 후, 이전 화면으로 복귀하기 위해 좌측 swipe 시 pop이 되지 않았던 문제를 수정합니다.
  - 뒤로가기 버튼과 동일하게 swipe를 통한 화면 pop 시에도 route 정상적으로 pop 되는 것 확인
  - [reference](https://stackoverflow.com/questions/59234958/swiftui-navigationbarbackbuttonhidden-swipe-back-gesture/60067845#60067845)


## 📸 ScreenShot
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/4d84184b-5271-4a92-a85e-b80b4d1aa003" width="200">



##### ✅ PR check list(PR 요청시 확인후 삭제해주세요)

```
- commit message가 적절한지 확인해주세요.
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```



#### Linked Issue

close #238 
