### PR TITLE
[Fix] #250 영업시간 하단 시트 필터에서 영업시간보기 필터 버튼 제거

### DIFF
--- a/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheetViewState.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheetViewState.swift
@@ -170,7 +170,6 @@ enum CafeFilter {
   }
 
   enum RunningTimeOption: Int, Equatable, CaseIterable {
-    case viewOnMap
     case running
     case twentyFourHours
 
@@ -180,8 +179,6 @@ enum CafeFilter {
 
     var title: String {
       switch self {
-      case .viewOnMap:
-        return "🕐 지도에서 보기"
       case .running:
         return "영업중"
       case .twentyFourHours:


### PR DESCRIPTION
## ☕️ PR 요약

해당 pr에서 작업한 내역을 적어주세요.
- 영업시간 하단 시트 필터에서 영업시간보기 필터 버튼을 제거했습니다. (floating button으로 변경되어서 불필요해짐)


## 📸 ScreenShot
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/ebb894ea-a9cd-44c6-9181-de96165e3888" width="200">


##### ✅ PR check list(PR 요청시 확인후 삭제해주세요)

```
- commit message가 적절한지 확인해주세요.
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```



#### Linked Issue

close #250 
