### PR TITLE
[Fix] #252 바텀시트 표출/숨김 애니메이션 속도 수정 (easeOut 0.3 -> 0.2 seconds)

### DIFF
--- a/Projects/Coffice/Sources/App/CommonComponents/CommonBottomSheet/BottomSheet.swift
+++ b/Projects/Coffice/Sources/App/CommonComponents/CommonBottomSheet/BottomSheet.swift
@@ -22,6 +22,7 @@ struct BottomSheetContent: Equatable {
       .closeOnTapOutside(true)
       .closeOnTap(false)
       .backgroundColor(CofficeAsset.Colors.grayScale10.swiftUIColor.opacity(0.4))
+      .animation(.easeOut(duration: 0.2))
   }
   static let mock = BottomSheetContent(
     title: "제목",


### PR DESCRIPTION
## ☕️ PR 요약
- QA팀 요청에 따라 바텀시트 표출/숨김 애니메이션 속도를 수정했습니다.
  - PopupView library의 기본 애니메이션 속도는 0.3초인데, 0.2초로 변경했습니다.


## 📸 ScreenShot
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/20116c1f-52f5-4d5b-b441-64053e62ef5f" width="200">



##### ✅ PR check list(PR 요청시 확인후 삭제해주세요)

```
- commit message가 적절한지 확인해주세요.
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```



#### Linked Issue

close #252 
