### PR TITLE
Feature/#270 로그인 타입 여러개인경우 소셜 로그인 상태가 먼저 노출되도록 변경

### DIFF
--- a/Projects/Coffice/Project.swift
+++ b/Projects/Coffice/Project.swift
@@ -11,7 +11,7 @@ let project = Project.app(
   iOSTargetVersion: iOSTargetVersion,
   infoPlist: [
     "CFBundleShortVersionString": "1.0.1", // 앱의 출시 버전
-    "CFBundleVersion": "0", // 앱의 빌드 버전 (테스트 플라이트 배포시 빌드 버전 up 필요)
+    "CFBundleVersion": "1", // 앱의 빌드 버전 (테스트 플라이트 배포시 빌드 버전 up 필요)
     "CFBundleDisplayName": "coffice", // 사용자에게 보여질 앱의 이름
     "UILaunchStoryboardName": "LaunchScreen",
     "UIInterfaceOrientation": ["UIInterfaceOrientationPortrait"],

--- a/Projects/Coffice/Sources/App/Entities/User.swift
+++ b/Projects/Coffice/Sources/App/Entities/User.swift
@@ -13,6 +13,16 @@ struct User: Hashable {
   let id: Int
   let loginTypes: [LoginType]
   let name: String
+  var loginType: LoginType? {
+    loginTypes.sorted {
+      if $0 == .anonymous {
+        return false
+      } else if $1 == .anonymous {
+        return true
+      }
+      return true
+    }.first
+  }
 }
 
 extension MemberResponseDTO {

--- a/Projects/Coffice/Sources/App/Main/MyPage/MyPageView.swift
+++ b/Projects/Coffice/Sources/App/Main/MyPage/MyPageView.swift
@@ -76,7 +76,7 @@ struct MyPageView: View {
         nickNameView
           .padding(.top, 110)
 
-        if viewStore.user?.loginTypes.contains(.anonymous) == true {
+        if viewStore.user?.loginType == .anonymous {
           Color.clear
             .frame(width: 0, height: 0)
             .padding(.top, 56)
@@ -109,14 +109,14 @@ struct MyPageView: View {
             .delegate(
               .editProfileButtonTapped(
                 nickname: viewStore.user?.name ?? "-",
-                loginType: viewStore.user?.loginTypes.first ?? .anonymous
+                loginType: viewStore.user?.loginType ?? .anonymous
               )
             )
           )
         } label: {
           HStack(spacing: 0) {
             Text(
-              viewStore.user?.loginTypes.first == .anonymous
+              viewStore.user?.loginType == .anonymous
               ? "SNS 로그인"
               : "편집"
             )
@@ -145,10 +145,10 @@ struct MyPageView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
 
           HStack(spacing: 8) {
-            viewStore.user?.loginTypes.first?.image
+            viewStore.user?.loginType?.image
               .resizable()
               .frame(width: 18, height: 18)
-            Text(viewStore.user?.loginTypes.first?.displayName ?? "")
+            Text(viewStore.user?.loginType?.displayName ?? "")
               .applyCofficeFont(font: .body2Medium)
               .foregroundColor(CofficeAsset.Colors.grayScale6.swiftUIColor)
               .padding(.trailing, 10)


### PR DESCRIPTION
## ☕️ PR 요약

- 익명 유저가 OAuth 로그인 한 경우 서버에는 사용자의 loginTypes로 ANONYMOUS와 KAKAO를 둘 다 담아서 보내줍니다.
  - 기존 로직에서는 loginTypes중 가장 첫번째 값을 사용했지만, 이때 익명이 첫번째 값에 포함되어있는 경우 익명 사용자로 취급되었었기에 이를 수정했습니다.

#### Linked Issue

close #270
