### PR TITLE
Feature/#273 cafe map view filter search

### DIFF
--- a/Projects/Coffice/Sources/App/Main/Search/CafeMapCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeMapCore.swift
@@ -414,7 +414,7 @@ struct CafeMapCore: ReducerProtocol {
             userLatitude: state.naverMapState.currentCameraPosition.latitude,
             userLongitude: state.naverMapState.currentCameraPosition.longitude,
             maximumSearchDistance: 2000,
-            isOpened: nil,
+            isOpened: information.isOpened,
             openAroundTheClock: information.openAroundTheClock,
             hasCommunalTable: information.hasCommunalTable,
             filters: information.cafeSearchFilters,

--- a/Projects/Coffice/Sources/App/Main/Search/CafeMapCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeMapCore.swift
@@ -405,10 +405,23 @@ struct CafeMapCore: ReducerProtocol {
 
       case .cafeFilterMenusAction(.delegate(.updateCafeFilter(let information))):
         state.cafeFilterInformation = information
-        return EffectTask(value: .cafeSearchListAction(
+        return .merge(
+          EffectTask(value: .cafeSearchListAction(
           .cafeFilterMenus(action: .updateCafeFilter(information: information))
-        ))
-
+          )),
+          EffectTask(value: .searchPlacesWithRequestValue(SearchPlaceRequestValue(
+            searchText: "",
+            userLatitude: state.naverMapState.currentCameraPosition.latitude,
+            userLongitude: state.naverMapState.currentCameraPosition.longitude,
+            maximumSearchDistance: 2000,
+            isOpened: nil,
+            openAroundTheClock: information.openAroundTheClock,
+            hasCommunalTable: information.hasCommunalTable,
+            filters: information.cafeSearchFilters,
+            pageSize: 30,
+            pageableKey: nil)
+          ))
+        )
       case .cardViewTapped:
         guard let cafe = state.naverMapState.selectedCafe
         else { return .none }

--- a/Projects/Coffice/Sources/App/Main/Search/CafeMapCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeMapCore.swift
@@ -407,7 +407,7 @@ struct CafeMapCore: ReducerProtocol {
         state.cafeFilterInformation = information
         return .merge(
           EffectTask(value: .cafeSearchListAction(
-          .cafeFilterMenus(action: .updateCafeFilter(information: information))
+            .cafeFilterMenus(action: .updateCafeFilter(information: information))
           )),
           EffectTask(value: .searchPlacesWithRequestValue(SearchPlaceRequestValue(
             searchText: "",


### PR DESCRIPTION
## ☕️ PR 요약

지도 초기 화면에서 현위치 재검색을 통해 카페 마커가 표출된 후, 필터를 적용하면 그 필터가 적용된 카페 결과 값이 조회되어야 함



## 📸 ScreenShot
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/108966759/ac4347b0-e148-46a5-86f4-682048b5ceb9" width="200">



#### Linked Issue

close #273 
