### PR TITLE
[Fix] #280 약관동의 하단 시트 아이콘 뿐만아니라 리스트 셀 전체가 터치영역 이어야함

### DIFF
--- a/Projects/Coffice/Sources/App/Login/LoginServiceTermsBottomSheetView.swift
+++ b/Projects/Coffice/Sources/App/Login/LoginServiceTermsBottomSheetView.swift
@@ -27,18 +27,18 @@ struct LoginServiceTermsBottomSheetView: View {
           .padding(.top, 28)
           .padding(.bottom, 20)
 
-        HStack(spacing: 16) {
-          Button {
-            viewStore.send(.wholeTermsAgreementButtonTapped)
-          } label: {
+        Button {
+          viewStore.send(.wholeTermsAgreementButtonTapped)
+        } label: {
+          HStack(spacing: 16) {
             viewStore.wholeTermsAgreementCheckboxImage.swiftUIImage
               .renderingMode(.template)
               .foregroundColor(viewStore.wholeTermsAgreementCheckboxColor.swiftUIColor)
+            Text("약관 전체 동의")
+              .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
+              .applyCofficeFont(font: .subtitle1Medium)
+              .frame(maxWidth: .infinity, alignment: .leading)
           }
-          Text("약관 전체 동의")
-            .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
-            .applyCofficeFont(font: .subtitle1Medium)
-          Spacer()
         }
         .frame(height: 32)
         .padding(.vertical, 20)


### PR DESCRIPTION
## ☕️ PR 요약
- 약관동의 하단 시트의 "약관 전체 동의" 영역이 아이콘 뿐만아니라 리스트 셀 전체가 터치영역이 되도록 수정했습니다.



## 📸 ScreenShot

<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/df5971fb-1c6a-49b6-bed9-391ab7291fd8" width="200">



##### ✅ PR check list(PR 요청시 확인후 삭제해주세요)

```
- commit message가 적절한지 확인해주세요.
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```



#### Linked Issue

close #280 
