### PR TITLE
[Feat] #285 카페 상세의 리뷰 태그, 긍정적인 내용 이외의 ‘콘센트가 적어요’ 같은 값도 보이도록 수정

### DIFF
--- a/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailMenuCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailMenuCore.swift
@@ -189,12 +189,11 @@ struct CafeDetailMenuReducer: ReducerProtocol {
               userName: review.memberName,
               date: review.createdDate,
               content: review.content ?? "",
-              tagTypes: [
-                review.outletOption == .enough ? .enoughOutlets : nil,
-                review.wifiOption == .fast ? .fastWifi : nil,
-                review.noiseOption == .quiet ? .quiet : nil
-              ]
-                .compactMap { $0 },
+              reviewTagTitles: [
+                review.outletOption.tagTitle,
+                review.wifiOption.tagTitle,
+                review.noiseOption.tagTitle
+              ],
               isMyReview: review.memberId == userId,
               outletOption: review.outletOption,
               wifiOption: review.wifiOption,
@@ -329,12 +328,11 @@ struct CafeDetailMenuReducer: ReducerProtocol {
             userName: review.memberName,
             date: review.createdDate,
             content: review.content ?? "",
-            tagTypes: [
-              review.outletOption == .enough ? .enoughOutlets : nil,
-              review.wifiOption == .fast ? .fastWifi : nil,
-              review.noiseOption == .quiet ? .quiet : nil
-            ]
-              .compactMap { $0 },
+            reviewTagTitles: [
+              review.outletOption.tagTitle,
+              review.wifiOption.tagTitle,
+              review.noiseOption.tagTitle
+            ],
             isMyReview: review.memberId == userId,
             outletOption: review.outletOption,
             wifiOption: review.wifiOption,
@@ -355,12 +353,11 @@ struct CafeDetailMenuReducer: ReducerProtocol {
           userName: review.memberName,
           date: review.createdDate,
           content: review.content ?? "",
-          tagTypes: [
-            review.outletOption == .enough ? .enoughOutlets : nil,
-            review.wifiOption == .fast ? .fastWifi : nil,
-            review.noiseOption == .quiet ? .quiet : nil
-          ]
-            .compactMap { $0 },
+          reviewTagTitles: [
+            review.outletOption.tagTitle,
+            review.wifiOption.tagTitle,
+            review.noiseOption.tagTitle
+          ],
           isMyReview: review.memberId == userId,
           outletOption: review.outletOption,
           wifiOption: review.wifiOption,
@@ -559,7 +556,7 @@ struct UserReviewCellState: Hashable, Identifiable {
   let userName: String
   let date: Date?
   let content: String
-  let tagTypes: [ReviewTagType]
+  let reviewTagTitles: [String]
   let isMyReview: Bool
   let outletOption: ReviewOption.OutletOption
   let wifiOption: ReviewOption.WifiOption
@@ -572,23 +569,6 @@ struct UserReviewCellState: Hashable, Identifiable {
     dateFormatter.locale = Locale(identifier: "ko_KR")
     dateFormatter.dateFormat = "M.dd E"
     return dateFormatter.string(from: date)
-  }
-}
-
-enum ReviewTagType: CaseIterable {
-  case enoughOutlets
-  case fastWifi
-  case quiet
-
-  var title: String {
-    switch self {
-    case .enoughOutlets:
-      return "🔌 콘센트 넉넉해요"
-    case .fastWifi:
-      return "📶 와이파이 빨라요"
-    case .quiet:
-      return "🔊 조용해요"
-    }
   }
 }
 

--- a/Projects/Coffice/Sources/App/Main/Search/CafeDetail/Review/CafeReviewOptionButtonsCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeDetail/Review/CafeReviewOptionButtonsCore.swift
@@ -46,7 +46,7 @@ struct CafeReviewOptionButtons: ReducerProtocol {
         optionButtonViewStates = ReviewOption.OutletOption.allCases
           .map {
             OptionButtonViewState(
-              title: $0.title,
+              title: $0.buttonTitle,
               optionType: ReviewOption.outletState(option == $0 ? $0 : nil)
             )
           }
@@ -54,7 +54,7 @@ struct CafeReviewOptionButtons: ReducerProtocol {
         optionButtonViewStates = ReviewOption.WifiOption.allCases
           .map {
             OptionButtonViewState(
-              title: $0.title,
+              title: $0.buttonTitle,
               optionType: ReviewOption.wifiState(option == $0 ? $0 : nil)
             )
           }
@@ -62,7 +62,7 @@ struct CafeReviewOptionButtons: ReducerProtocol {
         optionButtonViewStates = ReviewOption.NoiseOption.allCases
           .map {
             OptionButtonViewState(
-              title: $0.title,
+              title: $0.buttonTitle,
               optionType: ReviewOption.noise(option == $0 ? $0 : nil)
             )
           }
@@ -134,7 +134,7 @@ extension CafeReviewOptionButtons.State {
   }
 }
 
-enum ReviewOption: Equatable {
+enum ReviewOption: Hashable {
   case outletState(OutletOption?)
   case wifiState(WifiOption?)
   case noise(NoiseOption?)
@@ -162,8 +162,23 @@ enum ReviewOption: Equatable {
       case .some:
         return "적당해요"
       case .enough:
-        return "넉넉해요 👍"
+        return "넉넉해요"
       }
+    }
+
+    var buttonTitle: String {
+      switch self {
+      case .few:
+        return title
+      case .some:
+        return title
+      case .enough:
+        return "\(title) 👍"
+      }
+    }
+
+    var tagTitle: String {
+      return "🔌 콘센트 \(title)"
     }
 
     var dtoName: String {
@@ -187,8 +202,21 @@ enum ReviewOption: Equatable {
       case .slow:
         return "아쉬워요"
       case .fast:
-        return "빨라요 👍"
+        return "빨라요"
       }
+    }
+
+    var buttonTitle: String {
+      switch self {
+      case .slow:
+        return title
+      case .fast:
+        return "\(title) 👍"
+      }
+    }
+
+    var tagTitle: String {
+      return "📶 와이파이 \(title)"
     }
 
     var dtoName: String {
@@ -213,8 +241,23 @@ enum ReviewOption: Equatable {
       case .normal:
         return "보통이에요"
       case .quiet:
-        return "조용해요 👍"
+        return "조용해요"
       }
+    }
+
+    var buttonTitle: String {
+      switch self {
+      case .loud:
+        return title
+      case .normal:
+        return title
+      case .quiet:
+        return "\(title) 👍"
+      }
+    }
+
+    var tagTitle: String {
+      return "🔊 \(title)"
     }
 
     var dtoName: String {

--- a/Projects/Coffice/Sources/App/Main/Search/CafeDetail/UserReviewCell.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeDetail/UserReviewCell.swift
@@ -72,10 +72,10 @@ struct UserReviewCell: View {
           .padding(.top, 20)
 
         // TODO: Tag가 한줄 넘어갈 경우 넘어가도록 커스텀 뷰 구현 필요
-        if viewState.tagTypes.isNotEmpty {
+        if viewState.reviewTagTitles.isNotEmpty {
           HStack(spacing: 8) {
-            ForEach(viewState.tagTypes, id: \.self) { tagType in
-              Text(tagType.title)
+            ForEach(viewState.reviewTagTitles, id: \.self) { tagTitle in
+              Text(tagTitle)
                 .foregroundColor(CofficeAsset.Colors.grayScale7.swiftUIColor)
                 .applyCofficeFont(font: .body2Medium)
                 .frame(height: 18)


### PR DESCRIPTION
## ☕️ PR 요약
- 기존에는 리뷰 태그에 긍적적인 내용만 보이고 있었습니다.
  - 긍정적인 내용 이외의 내용 ex) ‘콘센트가 적어요’ 같은 값도 보이도록 수정했습니다.



## 📸 ScreenShot
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/68054c86-ba4a-4454-8d2d-d3a3b3b78245" width="200">



##### ✅ PR check list(PR 요청시 확인후 삭제해주세요)

```
- commit message가 적절한지 확인해주세요.
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```



#### Linked Issue

close #285 
