### PR TITLE
[Fix] #282, #283 필터 바텀시트 초기화 사양, 설명 메세지뷰 하단 흰띠 보이는 문제 수정

### DIFF
--- a/Projects/Coffice/Sources/App/CommonComponents/BubbleMessage/BubbleMessageView.swift
+++ b/Projects/Coffice/Sources/App/CommonComponents/BubbleMessage/BubbleMessageView.swift
@@ -19,8 +19,6 @@ struct BubbleMessageView: View {
   var body: some View {
     WithViewStore(store) { viewStore in
       ZStack(alignment: .center) {
-        Color.black.opacity(0.4).ignoresSafeArea()
-
         VStack(alignment: .leading, spacing: 0) {
           Text(viewStore.title)
             .foregroundColor(Color(asset: CofficeAsset.Colors.grayScale8))
@@ -55,7 +53,7 @@ struct BubbleMessageView: View {
         }
         .padding(20)
         .frame(width: 204, alignment: .center)
-        .background(Color(asset: CofficeAsset.Colors.grayScale1))
+        .background(CofficeAsset.Colors.grayScale1.swiftUIColor)
         .cornerRadius(8)
       }
     }

--- a/Projects/Coffice/Sources/App/Main/MyPage/DevTest/DevTestCore.swift
+++ b/Projects/Coffice/Sources/App/Main/MyPage/DevTest/DevTestCore.swift
@@ -85,14 +85,12 @@ struct DevTest: ReducerProtocol {
     // MARK: Cafe Filter Bottom Sheet
     Reduce { state, action in
       switch action {
-      case .cafeFilterBottomSheetAction(let action):
+      case .cafeFilterBottomSheetAction(.delegate(let action)):
         switch action {
         case .saveCafeFilter(let information):
           debugPrint("saved information : \(information)")
         case .dismiss:
           state.cafeFilterBottomSheetState = nil
-        default:
-          return .none
         }
         return .none
 

--- a/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailMenuCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailMenuCore.swift
@@ -120,7 +120,6 @@ struct CafeDetailMenuReducer: ReducerProtocol {
         return EffectTask(value: .fetchUserData)
 
       case .userReviewCellDidAppear(let currentCellState):
-        debugPrint("@@@ lastSeenReviewId : \(currentCellState.reviewId)")
         guard let lastReviewCellState = state.userReviewCellStates.last,
               lastReviewCellState == currentCellState,
               state.lastSeenReviewId != currentCellState.reviewId,

--- a/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheet.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheet.swift
@@ -55,7 +55,6 @@ struct CafeFilterBottomSheet: ReducerProtocol {
 
   enum Action: Equatable, BindableAction {
     case binding(BindingAction<State>)
-    case dismiss
     case presentBottomSheet
     case hideBottomSheet
     case optionButtonTapped(optionType: CafeFilter.OptionType)
@@ -66,8 +65,13 @@ struct CafeFilterBottomSheet: ReducerProtocol {
     case resetCafeFilter
     case saveCafeFilterButtonTapped
     case updateContainerView(height: CGFloat)
-    case saveCafeFilter(information: CafeFilterInformation)
     case bubbleMessageAction(BubbleMessage.Action)
+    case delegate(Delegate)
+  }
+
+  enum Delegate: Equatable {
+    case saveCafeFilter(information: CafeFilterInformation)
+    case dismiss
   }
 
   @Dependency(\.placeAPIClient) private var placeAPIClient
@@ -143,7 +147,10 @@ struct CafeFilterBottomSheet: ReducerProtocol {
         return .none
 
       case .resetCafeFilterButtonTapped:
-        return EffectTask(value: .resetCafeFilter)
+        return .merge(
+          EffectTask(value: .resetCafeFilter),
+          EffectTask(value: .delegate(.saveCafeFilter(information: state.cafeFilterInformation)))
+        )
 
       case .resetCafeFilter:
         switch state.filterType {
@@ -161,7 +168,7 @@ struct CafeFilterBottomSheet: ReducerProtocol {
         return EffectTask(value: .updateMainViewState)
 
       case .saveCafeFilterButtonTapped:
-        return EffectTask(value: .saveCafeFilter(information: state.cafeFilterInformation))
+        return EffectTask(value: .delegate(.saveCafeFilter(information: state.cafeFilterInformation)))
 
       case .updateContainerView(let height):
         state.containerViewHeight = height

--- a/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheet.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheet.swift
@@ -147,10 +147,7 @@ struct CafeFilterBottomSheet: ReducerProtocol {
         return .none
 
       case .resetCafeFilterButtonTapped:
-        return .merge(
-          EffectTask(value: .resetCafeFilter),
-          EffectTask(value: .delegate(.saveCafeFilter(information: state.cafeFilterInformation)))
-        )
+        return EffectTask(value: .resetCafeFilter)
 
       case .resetCafeFilter:
         switch state.filterType {
@@ -165,10 +162,16 @@ struct CafeFilterBottomSheet: ReducerProtocol {
         case .runningTime:
           state.cafeFilterInformation.runningTimeOptionSet.removeAll()
         }
-        return EffectTask(value: .updateMainViewState)
+        return .concatenate(
+          EffectTask(value: .delegate(.saveCafeFilter(information: state.cafeFilterInformation))),
+          EffectTask(value: .delegate(.dismiss))
+        )
 
       case .saveCafeFilterButtonTapped:
-        return EffectTask(value: .delegate(.saveCafeFilter(information: state.cafeFilterInformation)))
+        return .concatenate(
+          EffectTask(value: .delegate(.saveCafeFilter(information: state.cafeFilterInformation))),
+          EffectTask(value: .delegate(.dismiss))
+        )
 
       case .updateContainerView(let height):
         state.containerViewHeight = height

--- a/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheetView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheetView.swift
@@ -72,7 +72,7 @@ extension CafeFilterBottomSheetView {
         Spacer()
 
         Button {
-          viewStore.send(.dismiss)
+          viewStore.send(.delegate(.dismiss))
         } label: {
           CofficeAsset.Asset.close40px.swiftUIImage
             .padding(.top, 24)

--- a/Projects/Coffice/Sources/App/Main/Search/CafeFilterMenusCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeFilterMenusCore.swift
@@ -109,7 +109,6 @@ struct CafeFilterMenus: ReducerProtocol {
       case .cafeFilterBottomSheetViewAction(.delegate(let action)):
         switch action {
         case .saveCafeFilter(let information):
-          state.cafeFilterBottomSheetState = nil
           return EffectTask(value: .delegate(.updateCafeFilter(information: information)))
         case .dismiss:
           state.cafeFilterBottomSheetState = nil

--- a/Projects/Coffice/Sources/App/Main/Search/CafeFilterMenusCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeFilterMenusCore.swift
@@ -106,15 +106,13 @@ struct CafeFilterMenus: ReducerProtocol {
         state.updateButtonViewStates()
         return .none
 
-      case .cafeFilterBottomSheetViewAction(let action):
+      case .cafeFilterBottomSheetViewAction(.delegate(let action)):
         switch action {
         case .saveCafeFilter(let information):
           state.cafeFilterBottomSheetState = nil
           return EffectTask(value: .delegate(.updateCafeFilter(information: information)))
         case .dismiss:
           state.cafeFilterBottomSheetState = nil
-          return .none
-        default:
           return .none
         }
 


### PR DESCRIPTION
## ☕️ PR 요약
- #282 필터 바텀시트 초기화 사양 수정

|          AS-IS          |          TO-BE          |
| :---------------------: | :---------------------: |
| (스크린샷을 넣어주세요) | <img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/2d6b5b65-16e9-4863-96ec-2588f51ea552" width="200"> |

- #283 설명 메세지뷰 하단 흰띠 보이는 문제 수정

|          AS-IS          |          TO-BE          |
| :---------------------: | :---------------------: |
| (스크린샷을 넣어주세요) | <img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/327d71ea-b394-40c0-a250-4940fe588e1f" width="200"> |

## 📸 ScreenShot
#280 #283 



##### ✅ PR check list(PR 요청시 확인후 삭제해주세요)

```
- commit message가 적절한지 확인해주세요.
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```



#### Linked Issue

close #282 #283 
