### PR TITLE
[Feat] #297 카페상세, 저장리스트 refresh control 적용

### DIFF
--- a/Projects/Coffice/Sources/App/Main/SavedList/SavedListCore.swift
+++ b/Projects/Coffice/Sources/App/Main/SavedList/SavedListCore.swift
@@ -25,6 +25,7 @@ struct SavedList: ReducerProtocol {
   enum Action: Equatable {
     case onAppear
     case onDisappear
+    case fetchMyPlaces
     case bookmarkButtonTapped(cafe: Cafe)
     case bookmarkedCafeResponse(cafes: [Cafe])
     case deleteCafesFromBookmark
@@ -37,6 +38,14 @@ struct SavedList: ReducerProtocol {
     Reduce { state, action in
       switch action {
       case .onAppear:
+        return EffectTask(value: .fetchMyPlaces)
+
+      case .onDisappear:
+        return .run { send in
+          await send(.deleteCafesFromBookmark)
+        }
+
+      case .fetchMyPlaces:
         return .run { send in
           let bookmarkedCafes = try await bookmarkClient.fetchMyPlaces()
           await send(
@@ -44,11 +53,6 @@ struct SavedList: ReducerProtocol {
           )
         } catch: { error, send in
           debugPrint(error)
-        }
-
-      case .onDisappear:
-        return .run { send in
-          await send(.deleteCafesFromBookmark)
         }
 
       case .bookmarkButtonTapped(let cafe):

--- a/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
+++ b/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
@@ -100,6 +100,9 @@ struct SavedListView: View {
           }
           .padding(.horizontal, 20)
         }
+        .refreshable { @MainActor in
+          viewStore.send(.fetchMyPlaces)
+        }
       }
     }
   }

--- a/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailCore.swift
@@ -70,9 +70,7 @@ struct CafeDetail: ReducerProtocol {
     Reduce { state, action in
       switch action {
       case .onAppear:
-        return .merge(
-          EffectTask(value: .fetchPlace)
-        )
+        return EffectTask(value: .fetchPlace)
 
       case .fetchPlace:
         return .run { [cafeId = state.cafeId] send in

--- a/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailMenuCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailMenuCore.swift
@@ -56,7 +56,10 @@ struct CafeDetailMenuReducer: ReducerProtocol {
 
     mutating func update(cafe: Cafe?) -> EffectTask<Action> {
       self.cafe = cafe
-      return EffectTask(value: .fetchReviews)
+      return .concatenate(
+        EffectTask(value: .resetReviews),
+        EffectTask(value: .fetchReviews)
+      )
     }
   }
 
@@ -77,6 +80,7 @@ struct CafeDetailMenuReducer: ReducerProtocol {
     case dismissWebView
 
     // MARK: User Review
+    case resetReviews
     case cafeReviewWrite(action: CafeReviewWrite.Action)
     case bottomSheet(action: BottomSheetReducer.Action)
     case fetchReviews
@@ -178,6 +182,12 @@ struct CafeDetailMenuReducer: ReducerProtocol {
     // MARK: - Review
     Reduce { state, action in
       switch action {
+      case .resetReviews:
+        state.hasNextReview = false
+        state.lastSeenReviewId = nil
+        state.userReviewCellStates = []
+        return .none
+
       case .updateReviewCellStates(let reviewsResponse):
         state.hasNextReview = reviewsResponse.hasNext
         state.userReviewCellStates += reviewsResponse.reviews

--- a/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailView.swift
@@ -45,6 +45,10 @@ struct CafeDetailView: View {
             )
           }
         }
+        .padding(.top, UIApplication.keyWindow?.safeAreaInsets.top ?? 0.0)
+        .refreshable { @MainActor in
+          viewStore.send(.fetchPlace)
+        }
       }
       .navigationBarHidden(true)
       .ignoresSafeArea(.all, edges: .top)


### PR DESCRIPTION
## ☕️ PR 요약
- 카페상세, 저장리스트 refresh control알 적용했습니다.
- refreshable viewModifier를 사용하는 방식으로 적용했는데, iOS16 이상에서 기능이 동작하고 있습니다. (시뮬레이터 iOS15에서는 pull to refresh 동작이 안됨) 
- refreshable block에 메인스레드 관련 에러 로그가 남아서 MainActor를 적용했습니다.


## 📸 ScreenShot
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/a1597424-6fab-4a84-94f9-2e7f030a1658" width="200">


##### ✅ PR check list(PR 요청시 확인후 삭제해주세요)

```
- commit message가 적절한지 확인해주세요.
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```



#### Linked Issue

close #297 
