### PR TITLE
[Feat] #299 카페상세 상단 공유버튼 기능 추가

### DIFF
--- a/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailHeaderCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailHeaderCore.swift
@@ -22,6 +22,15 @@ struct CafeDetailHeaderReducer: ReducerProtocol {
       self.cafe = cafe
       return .none
     }
+
+    var urlToShare: URL? {
+      guard let latitude = cafe?.latitude, let longitude = cafe?.longitude
+      else { return nil }
+      let longitudeInEPSG3857 = (longitude * 20037508.34 / 180)
+      let latitudeInEPSG3857 = (log(tan((90 + latitude) * Double.pi / 360)) / (Double.pi / 180)) * (20037508.34 / 180)
+
+      return URL(string: "https://map.naver.com/v5/?c=\(longitudeInEPSG3857),\(latitudeInEPSG3857),18,0,0,0,dh")
+    }
   }
 
   enum Action: Equatable {

--- a/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailHeaderView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailHeaderView.swift
@@ -73,6 +73,32 @@ struct CafeDetailHeaderView: View {
         }
         .padding(EdgeInsets(top: 20, leading: 20, bottom: 16, trailing: 20))
       }
+      .overlay(
+        alignment: .top,
+        content: {
+          HStack {
+            Spacer()
+
+            if let urlToShare = viewStore.urlToShare {
+              Button {
+                let activityViewController = UIActivityViewController(
+                  activityItems: [urlToShare],
+                  applicationActivities: nil
+                )
+                UIApplication.keyWindow?.rootViewController?.present(
+                  activityViewController, animated: true, completion: nil
+                )
+              } label: {
+                CofficeAsset.Asset.shareBoxFill40px.swiftUIImage
+                  .renderingMode(.template)
+                  .foregroundColor(CofficeAsset.Colors.grayScale1.swiftUIColor)
+              }
+            }
+          }
+          .padding(.top, 4)
+          .padding(.horizontal, 8)
+        }
+      )
     }
   }
 }

--- a/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailHeaderView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailHeaderView.swift
@@ -101,6 +101,7 @@ extension CafeDetailHeaderView {
         }
       }
       .frame(height: viewStore.imagePageViewHeight)
+      .offset(y: -(UIApplication.keyWindow?.safeAreaInsets.top ?? 0.0))
     }
   }
 

--- a/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeDetail/CafeDetailView.swift
@@ -65,18 +65,7 @@ struct CafeDetailView: View {
             }
 
             Spacer()
-
-            Button {
-              // TODO: 공유하기 기능 추가 필요
-            } label: {
-              CofficeAsset.Asset.shareBoxFill40px.swiftUIImage
-                .renderingMode(.template)
-                .foregroundColor(CofficeAsset.Colors.grayScale1.swiftUIColor)
-            }
-            .hiddenWithOpacity(isHidden: true)
           }
-          .padding(.top, 4)
-          .padding(.horizontal, 8)
         }
       )
       .onAppear {


### PR DESCRIPTION
## ☕️ PR 요약
- 카페상세 상단 공유버튼 기능을 추가했습니다.
- 앞서 넣었던 refresh control 기능 추가하면서 카페상세 이미지가 safeArea 영역이 잘리는 문제가 있어서 해당 이미지 영역의 offset y 값을 수정해서 원래 사양대로 보이도록 했습니다.
- 공유하는 네이버지도 URL은 정확한 카페 위치까지 잡지는 못하지만 기획과 협의해서 반영하기로 했습니다.


## 📸 ScreenShot
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/fd8234e1-0dd7-4a46-ab53-68f2275c1cc9" width="200">



##### ✅ PR check list(PR 요청시 확인후 삭제해주세요)

```
- commit message가 적절한지 확인해주세요.
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```



#### Linked Issue

close #299 
