### PR TITLE
[Fix] #323 저장리스트 목록이 스크롤 가능할 정도로 많을 경우 하단 정보가 잘려보이는 현상 수정

### DIFF
--- a/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
+++ b/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
@@ -22,6 +22,7 @@ struct SavedListView: View {
           mainView
         }
       }
+      .padding(.bottom, TabBarSizePreferenceKey.defaultValue.height)
       .onAppear {
         viewStore.send(.onAppear)
       }


### PR DESCRIPTION
- [x] 저장리스트 목록이 스크롤 가능할 정도로 많을 경우 하단 정보가 잘려보이는 현상 수정

<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/792f60bc-d305-4b6a-8d9b-4ea61ca8d295" width="200">



close #323 