### PR TITLE
[Fix] #319 thumbnail, placeholder image 사양 수정 후 저장리스트목록 모서리 레이아웃 사양 수정

### DIFF
--- a/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
+++ b/Projects/Coffice/Sources/App/Main/SavedList/SavedListView.swift
@@ -94,6 +94,8 @@ struct SavedListView: View {
                     .overlay(alignment: .topTrailing) {
                       bookmarkButton(cafe: cafe)
                     }
+                    .clipped()
+                    .cornerRadius(4)
                 }
                 Text(cafe.name)
                   .lineLimit(1)
@@ -146,9 +148,9 @@ struct SavedListView: View {
             height: (proxy.size.width - 60) / 2
           )
           .background(CofficeAsset.Colors.grayScale2.swiftUIColor)
-          .clipped()
-          .cornerRadius(5)
       }
+      .clipped()
+      .cornerRadius(4)
     }
   }
 


### PR DESCRIPTION
### 수정사항

- [Figma 링크](https://www.figma.com/file/DTaqBg0MpMjSgqUynaB564/Yapp_iOS_1_UI_Share?type=design&node-id=650-8978&mode=design&t=w5GOShcIkPT6OteV-0)
- thumbnail, placeholder image 들의 그레디언트 사양 반영 후, 저장리스트 화면 아이템 셀의 모서리가 둥글게 보이지 않는 문제, 사양과 다른 corner radius 값으로 되어 있어서 수정했습니다. (corner radius 5 -> 4)

### 수정 후 화면
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/c30545ef-f51d-40b8-9bb4-5575c05bb04b" width="200">
