### PR TITLE
[Fix] #327 - 프로필 편집화면 > swipe로 뒤로가기 시 마이페이지에서 탭바가 사라지지 않도록 수정

### DIFF
--- a/Projects/Coffice/Sources/App/Main/MainCoordinatorCore.swift
+++ b/Projects/Coffice/Sources/App/Main/MainCoordinatorCore.swift
@@ -82,14 +82,6 @@ struct MainCoordinator: Reducer {
         state.selectedTab = itemType
         return .none
 
-      case .myPage(.routeAction(_, .editProfile(.hideTabBar))):
-        state.shouldShowTabBarView = false
-        return .none
-
-      case .myPage(.routeAction(_, .editProfile(.showTabBar))):
-        state.shouldShowTabBarView = true
-        return .none
-
       default:
         return .none
       }

--- a/Projects/Coffice/Sources/App/Main/MyPage/EditProfile/EditProfileCore.swift
+++ b/Projects/Coffice/Sources/App/Main/MyPage/EditProfile/EditProfileCore.swift
@@ -42,8 +42,6 @@ struct EditProfile: Reducer {
     case confirmButtonTapped
     case checkNicknameResponse(response: CheckNicknameResponse)
     case clearText
-    case showTabBar
-    case hideTabBar
   }
 
   @Dependency(\.checkNicknameAPIClient) private var checkNicknameClient
@@ -56,10 +54,7 @@ struct EditProfile: Reducer {
         return .none
 
       case .dismissButtonTapped:
-        return .concatenate(
-          .send(.showTabBar),
-          .send(.popView)
-        )
+        return .send(.popView)
 
       case .binding(\.$nicknameTextField):
         return .none
@@ -77,10 +72,7 @@ struct EditProfile: Reducer {
       case .checkNicknameResponse(let response):
         state.nicknameValidationType = .checked(response: response)
         if state.nicknameValidationType == .checked(response: .valid) {
-          return .concatenate(
-            .send(.showTabBar),
-            .send(.popView)
-          )
+          return .send(.popView)
         }
         return .none
 

--- a/Projects/Coffice/Sources/App/Main/MyPage/EditProfile/EditProfileView.swift
+++ b/Projects/Coffice/Sources/App/Main/MyPage/EditProfile/EditProfileView.swift
@@ -35,9 +35,6 @@ struct EditProfileView: View {
             }
           }
         )
-        .onAppear {
-          viewStore.send(.hideTabBar)
-        }
     }
   }
 


### PR DESCRIPTION
- #327 
- 최근에 탭바 숨김/표출 로직을 구현하기 위해 탭바 표출로직을 변경했었는데요. (커스텀 탭뷰 방식으로 다시 변경) 그때 이전 탭바 표출로직을 마저 제거하지 못하면서, 사양에 맞지않게 탭바가 표출되는 문제가 있어서 수정했습니다.


close #327 