### PR TITLE
[Fix] #336 아이패드 > 일부 레이아웃이 SafeArea 없는 기기를 고려하지 않아서 생기는 문제 수정

### DIFF
--- a/Projects/Coffice/Sources/App/CommonComponents/CommonBottomSheet/BottomSheet.swift
+++ b/Projects/Coffice/Sources/App/CommonComponents/CommonBottomSheet/BottomSheet.swift
@@ -52,7 +52,7 @@ struct BottomSheetView: View {
       footerView
     }
     .frame(maxWidth: .infinity)
-    .padding(.bottom, UIApplication.keyWindow?.safeAreaInsets.bottom)
+    .padding(.bottom, 20 + (UIApplication.keyWindow?.safeAreaInsets.bottom ?? 0))
     .padding(.top, 20)
     .background(CofficeAsset.Colors.grayScale1.swiftUIColor)
     .cornerRadius(12, corners: [.topLeft, .topRight])

--- a/Projects/Coffice/Sources/App/Login/LoginView.swift
+++ b/Projects/Coffice/Sources/App/Login/LoginView.swift
@@ -28,62 +28,63 @@ struct LoginView: View {
       store,
       observe: { $0 },
       content: { viewStore in
-        VStack(alignment: .leading, spacing: 0) {
-          VStack(alignment: .center, spacing: 0) {
-            CofficeAsset.Asset.loginAppLogo.swiftUIImage
-              .padding(EdgeInsets(top: 0, leading: 60, bottom: 178, trailing: 60))
+        VStack(alignment: .center, spacing: 0) {
+          CofficeAsset.Asset.loginAppLogo.swiftUIImage
+            .padding(.top, 0)
+            .padding(.horizontal, 60)
 
-            Button {
-              viewStore.send(.kakaoLoginButtonTapped)
-            } label: {
-              HStack {
-                CofficeAsset.Asset.kakaoLogo18px.swiftUIImage
-                  .frame(width: 18, height: 18)
-                Text("카카오톡으로 로그인")
-                  .tint(.black)
-                  .applyCofficeFont(font: .subtitleSemiBold)
-              }
-              .frame(maxWidth: .infinity)
-            }
-            .frame(height: 52)
-            .background(CofficeAsset.Colors.kakao.swiftUIColor)
-            .cornerRadius(25)
-            .padding(.bottom, 16)
+          Spacer()
 
-            SignInWithAppleButton { request in
-              request.requestedScopes = []
-            } onCompletion: { result in
-              switch result {
-              case .success(let authResults):
-                guard let appleIDCredential = authResults.credential as? ASAuthorizationAppleIDCredential,
-                      let identityToken = appleIDCredential.identityToken,
-                      let token = String(data: identityToken, encoding: .utf8) else {
-                  return
-                }
-                viewStore.send(.appleLoginButtonTapped(token: token))
-              case .failure(let error):
-                debugPrint(error)
-              }
+          Button {
+            viewStore.send(.kakaoLoginButtonTapped)
+          } label: {
+            HStack {
+              CofficeAsset.Asset.kakaoLogo18px.swiftUIImage
+                .frame(width: 18, height: 18)
+              Text("카카오톡으로 로그인")
+                .tint(.black)
+                .applyCofficeFont(font: .subtitleSemiBold)
             }
-            .cornerRadius(25)
-            .frame(height: 50)
-            .padding(.bottom, 24)
-
-            HStack(spacing: 4) {
-              Text("회원가입 없이")
-              Button {
-                viewStore.send(.lookAroundButtonTapped)
-              } label: {
-                Text("둘러보기")
-                  .foregroundColor(CofficeAsset.Colors.secondary1.swiftUIColor)
-              }
-            }
-            .applyCofficeFont(font: .body1Medium)
-            .hiddenWithOpacity(isHidden: viewStore.isOnboarding.isFalse)
+            .frame(maxWidth: .infinity)
           }
-          .padding(EdgeInsets(top: 163, leading: 36, bottom: 129, trailing: 36))
+          .frame(height: 52)
+          .background(CofficeAsset.Colors.kakao.swiftUIColor)
+          .cornerRadius(25)
+          .padding(.bottom, 16)
+
+          SignInWithAppleButton { request in
+            request.requestedScopes = []
+          } onCompletion: { result in
+            switch result {
+            case .success(let authResults):
+              guard let appleIDCredential = authResults.credential as? ASAuthorizationAppleIDCredential,
+                    let identityToken = appleIDCredential.identityToken,
+                    let token = String(data: identityToken, encoding: .utf8) else {
+                return
+              }
+              viewStore.send(.appleLoginButtonTapped(token: token))
+            case .failure(let error):
+              debugPrint(error)
+            }
+          }
+          .cornerRadius(25)
+          .frame(height: 50)
+          .padding(.bottom, 24)
+
+          HStack(spacing: 4) {
+            Text("회원가입 없이")
+            Button {
+              viewStore.send(.lookAroundButtonTapped)
+            } label: {
+              Text("둘러보기")
+                .foregroundColor(CofficeAsset.Colors.secondary1.swiftUIColor)
+            }
+          }
+          .applyCofficeFont(font: .body1Medium)
+          .hiddenWithOpacity(isHidden: viewStore.isOnboarding.isFalse)
         }
         .navigationBarHidden(true)
+        .padding(EdgeInsets(top: 163, leading: 36, bottom: 129, trailing: 36))
         .overlay(
           alignment: .topLeading,
           content: {

--- a/Projects/Coffice/Sources/App/Main/Search/CafeDetail/Review/CafeReviewWriteView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeDetail/Review/CafeReviewWriteView.swift
@@ -90,21 +90,19 @@ struct CafeReviewWriteView: View {
 
           reviewFormScrollView
 
-          VStack(alignment: .center) {
-            Button {
-              viewStore.send(.saveButtonTapped)
-            } label: {
-              Text(viewStore.saveButtonTitle)
-                .foregroundColor(CofficeAsset.Colors.grayScale1.swiftUIColor)
-                .applyCofficeFont(font: .button)
-                .frame(maxWidth: .infinity)
-            }
-            .disabled(viewStore.isSaveButtonEnabled.isFalse)
+          Button {
+            viewStore.send(.saveButtonTapped)
+          } label: {
+            Text(viewStore.saveButtonTitle)
+              .foregroundColor(CofficeAsset.Colors.grayScale1.swiftUIColor)
+              .applyCofficeFont(font: .button)
+              .frame(maxWidth: .infinity)
           }
+          .disabled(viewStore.isSaveButtonEnabled.isFalse)
           .frame(height: 44)
           .background(viewStore.saveButtonBackgroundColorAsset.swiftUIColor)
           .cornerRadius(4, corners: .allCorners)
-          .padding(.horizontal, 20)
+          .padding(20)
         }
         .ignoresSafeArea(.keyboard)
         .onAppear {

--- a/Projects/Coffice/Sources/App/Main/Search/CafeMapView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeMapView.swift
@@ -72,6 +72,8 @@ struct CafeMapView: View {
               height: geometry.size.height
             )
           }
+          .ignoresSafeArea(.keyboard)
+          .padding(.bottom, 20)
           .onAppear {
             if geometry.size.width == 0 {
               viewStore.send(.updateMaxScreenWidth(UIScreen.main.bounds.width))

--- a/Projects/Coffice/Sources/App/Main/Search/CafeSearch/CafeSearchView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeSearch/CafeSearchView.swift
@@ -31,6 +31,7 @@ struct CafeSearchView: View {
           cafeSearchBodyView
         }
         .ignoresSafeArea(.keyboard)
+        .padding(.bottom, 20)
         .onAppear {
           focusField = .keyword
           viewStore.send(.onAppear)


### PR DESCRIPTION
- 아이패드 > 일부 레이아웃이 SafeArea 없는 기기를 고려하지 않아서 생기는 문제를 수정합니다. (일부 레이아웃이 SafeArea가 없는 케이스에 대한 대응이 안되어있어서 카드나 팝업 버튼이 바닥에 딱 붙어있는 경우 수정)

### 수정 후 화면
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/80819011-dc54-4945-9002-bc72b359f3ff" width="400">


close #336 