### PR TITLE
[Fix, 스크롤뷰를 적용하지않아 작은화면에서 버튼이 가려지는 이슈 디버깅]

### DIFF
--- a/Projects/Coffice/Sources/App/Main/MyPage/MyPageView.swift
+++ b/Projects/Coffice/Sources/App/Main/MyPage/MyPageView.swift
@@ -92,17 +92,20 @@ struct MyPageView: View {
           } else {
             linkedAccountTypeView
           }
-
-          VStack(spacing: 0) {
-            ForEach(viewStore.menuItems) { menuItem in
-              menuItemView(menuItem: menuItem)
+          
+          ScrollView(.vertical, showsIndicators: false) {
+            VStack(spacing: 0) {
+              ForEach(viewStore.menuItems) { menuItem in
+                menuItemView(menuItem: menuItem)
+              }
             }
+            .padding(.vertical, 10)
           }
-          .padding(.vertical, 10)
 
           Spacer()
         }
         .padding(.horizontal, 20)
+        .padding(.bottom, TabBarSizePreferenceKey.defaultValue.height)
       }
     )
   }


### PR DESCRIPTION
- VStack으로 적용되어있어 버튼이 많아지거나 작은 화면에서 하단의 버튼이 TabBar에 가려짐

버튼에 ScrollView 적용

https://github.com/YAPP-Github/Coffice-iOS/assets/31721888/b774511b-f06b-4b16-93ca-20c444663524

close #335 
