### PR TITLE
[Bug] #373 SafeArea 없는 기기 카페 필터 바텀시트 하단 버튼이 화면 끝에 딱 붙어 보이는 문제 수정

### DIFF
--- a/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheet.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheet.swift
@@ -43,7 +43,7 @@ struct CafeFilterBottomSheet: Reducer {
     var mainViewState: CafeFilterBottomSheetViewState = .init(optionButtonCellViewStates: [])
     var containerViewHeight: CGFloat = .zero
     let headerViewHeight: CGFloat = 80
-    let footerViewHeight: CGFloat = 84 + (UIApplication.keyWindow?.safeAreaInsets.bottom ?? 0.0)
+    let footerViewHeight: CGFloat = 84 + (UIApplication.keyWindow?.safeAreaInsets.bottom ?? 0) + 20.0
 
     init(filterType: CafeFilter.MenuType, cafeFilterInformation: CafeFilterInformation) {
       self.filterType = filterType

--- a/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheetView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeFilterBottomSheet/CafeFilterBottomSheetView.swift
@@ -202,7 +202,7 @@ extension CafeFilterBottomSheetView {
         }
         .padding(.horizontal, 20)
         .padding(.top, 8)
-        .padding(.bottom, UIApplication.keyWindow?.safeAreaInsets.bottom ?? 0)
+        .padding(.bottom, (UIApplication.keyWindow?.safeAreaInsets.bottom ?? 0) + 20.0)
       }
     )
   }


### PR DESCRIPTION
- SafeArea 없는 기기 카페 필터 바텀시트 하단 버튼이 화면 끝에 딱 붙어 보이는 문제를 수정합니다.

### AS-IS / TO-BE
<div>
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/db800217-3fae-4943-9b9c-f6ef7eee33da" width="200">
<img src="https://github.com/YAPP-Github/Coffice-iOS/assets/4410021/0e8294b6-04bb-4ccf-8cb7-69c642c1f5f3" width="200">
<div>
